### PR TITLE
ignore existing modules, recursive flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,6 +238,10 @@ FLAGS
   BORING_REGISTRY_GCS_PREFIX=...
   Prefix to use when using the GCS registry type.
 
+  -ignore-existing=true
+  BORING_REGISTRY_IGNORE_EXISTING=true
+  Ignore already existing modules. If set to false upload will fail immediately if a module already exists in that version.
+
   -json=false
   BORING_REGISTRY_JSON=false
   Output logs in JSON format.
@@ -245,6 +249,10 @@ FLAGS
   -no-color=false
   BORING_REGISTRY_NO_COLOR=false
   Disables colored output.
+
+  -recursive=true
+  BORING_REGISTRY_RECURSIVE=true
+  Recursively traverse <dir> and upload all modules in subdirectories.
 
   -s3-bucket=...
   BORING_REGISTRY_S3_BUCKET=...

--- a/README.md
+++ b/README.md
@@ -116,6 +116,33 @@ metadata {
 
 When running the upload command, the module is then packaged up and stored inside the registry. 
 
+### Recursive vs. non-recursive upload
+
+Walking the directory recursively is the default behavoir of `boring-registry upload`. This way all modules underneath theq
+current directory will be checked for `boring-registry.hcl` files and modules will be packaged and uploaded if they not
+already exist. However this can be unwanted in certain situations e.g. if a `.terraform` directory is present containing
+other modules that have a configuration file. The `-recursive=false` flag will omit this behavior. Here is a short example:
+
+### Fail early if module version already exists
+
+By default the upload command will silently ignore already uploaded versions of a module and return exit code `0`. For
+taging mono-repositories this can become a problem as it is not clear if the module version is new or already uploaded.
+The `-ignore-existing=false` parameter will force the upload command to return exit code `1` in such a case. In
+combination with `-recursive=false` the exit code can be used to tag the GIT repository only if a new version was uploaded.
+
+```shell
+for i in $(ls -d */); do
+  printf "Operating on module \"${i%%/}\"\n"
+  # upload the given directory
+  ./boring-registry upload -type gcs -gcs-bucket=my-boring-registry-upload-bucket -recursive=false -ignore-existing=false ${i%%/}
+  # tag the repo with a tag composed out of the boring-registry.hcl if not already exist
+  if [ $? -eq 0 ]; then
+    # git tag the repository with the version from boring-registry.hcl
+    # hint: use mattolenik/hclq to parse the hcl file
+  fi
+done
+```
+
 ## Help output
 
 ```

--- a/internal/cli/uploadcmd/upload.go
+++ b/internal/cli/uploadcmd/upload.go
@@ -28,6 +28,8 @@ type Config struct {
 	APIKey                 string
 	ListenAddress          string
 	TelemetryListenAddress string
+	UploadRecursive        bool
+	IgnoreExistingModule   bool
 }
 
 func (c *Config) Exec(ctx context.Context, args []string) error {
@@ -87,6 +89,9 @@ func New(config *rootcmd.Config) *ffcli.Command {
 	fs.StringVar(&cfg.S3Region, "s3-region", "", "Region of the S3 bucket when using the S3 registry type")
 	fs.StringVar(&cfg.GCSBucket, "gcs-bucket", "", "Bucket to use when using the GCS registry type")
 	fs.StringVar(&cfg.GCSPrefix, "gcs-prefix", "", "Prefix to use when using the GCS registry type")
+	fs.BoolVar(&cfg.UploadRecursive, "recursive", true, "Recursively traverse <dir> and upload all modules in subdirectories")
+	fs.BoolVar(&cfg.IgnoreExistingModule, "ignore-existing", true, "Ignore already existing modules. If set to false upload will fail immediately if a module already exists in that version")
+
 	config.RegisterFlags(fs)
 
 	return &ffcli.Command{

--- a/pkg/module/errors.go
+++ b/pkg/module/errors.go
@@ -14,3 +14,8 @@ var (
 var (
 	ErrVarMissing = errors.New("variable missing")
 )
+
+// Middleware errors.
+var (
+	ErrInvalidKey = errors.New("invalid key")
+)

--- a/pkg/module/middleware.go
+++ b/pkg/module/middleware.go
@@ -86,7 +86,7 @@ func AuthMiddleware(keys ...string) endpoint.Middleware {
 			}
 
 			if !found {
-				return nil, fmt.Errorf("invalid key")
+				return nil, ErrInvalidKey
 			}
 
 			return next(ctx, request)

--- a/pkg/module/transport.go
+++ b/pkg/module/transport.go
@@ -116,6 +116,8 @@ func ErrorEncoder(_ context.Context, err error, w http.ResponseWriter) {
 	switch errors.Cause(err) {
 	case ErrVarMissing:
 		w.WriteHeader(http.StatusBadRequest)
+	case ErrInvalidKey:
+		w.WriteHeader(http.StatusUnauthorized)
 	default:
 		w.WriteHeader(http.StatusInternalServerError)
 	}


### PR DESCRIPTION
With `-recursive=false` the upload will only handle the given directory and not walk the whole directory tree looking for `boring-registry.hcl` files.

With `-ignore-existing=false` the upload will fail if a module version already exists in a specific version and exit with error code 1 . This is useful in combination with `-recursive=false` to get an indication if the module version has changed.