### PR TITLE
fix(middleware): adjust invalid key response

### DIFF
--- a/pkg/module/errors.go
+++ b/pkg/module/errors.go
@@ -14,3 +14,8 @@ var (
 var (
 	ErrVarMissing = errors.New("variable missing")
 )
+
+// Middleware errors.
+var (
+	ErrInvalidKey = errors.New("invalid key")
+)

--- a/pkg/module/middleware.go
+++ b/pkg/module/middleware.go
@@ -86,7 +86,7 @@ func AuthMiddleware(keys ...string) endpoint.Middleware {
 			}
 
 			if !found {
-				return nil, fmt.Errorf("invalid key")
+				return nil, ErrInvalidKey
 			}
 
 			return next(ctx, request)

--- a/pkg/module/transport.go
+++ b/pkg/module/transport.go
@@ -116,6 +116,8 @@ func ErrorEncoder(_ context.Context, err error, w http.ResponseWriter) {
 	switch errors.Cause(err) {
 	case ErrVarMissing:
 		w.WriteHeader(http.StatusBadRequest)
+	case ErrInvalidKey:
+		w.WriteHeader(http.StatusUnauthorized)
 	default:
 		w.WriteHeader(http.StatusInternalServerError)
 	}


### PR DESCRIPTION
Return a proper response when the key is invalid.
Instead of 500 we now respond with a 401.
