### PR TITLE
Add -version-constraints flag to upload subcommand

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ for i in $(ls -d */); do
 done
 ```
 
+### Module version constraints
+
+The `-version-constraints` flag lets you specify a range of acceptable versions for modules.
+It expects a specially formatted string containing one or more conditions, which are separated by commas.
+The syntax is similar to the [Terraform Version Constraint Syntax](https://www.terraform.io/docs/language/expressions/version-constraints.html#version-constraint-syntax).
+
+In order to exclude all SemVer pre-releases, you can e.g. use `-version-constraints=">=v0"`, which will instruct the boring-registry cli to only upload non-pre-releases to the registry.
+This would for example allow you to prevent 
+
 ## Help output
 
 ```

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The registry supports two modes:
   * Server - The server runs the registry API
   * Upload - Uploads modules to the configured registry
 
-To run the server you need to specify which registry to use (currently only S3 is supported):
+To run the server you need to specify which registry to use:
 
 **Example using the S3 registry:**
 ```bash
@@ -296,6 +296,10 @@ FLAGS
   -type=...
   BORING_REGISTRY_TYPE=...
   Registry type to use (currently only "s3" and "gcs" is supported).
+  
+  -version-constraints=...
+  BORING_REGISTRY_VERSION_CONSTRAINTS=...
+  Limit the module versions that are eligible for upload with version constraints.
 ```
 
 # Roadmap

--- a/README.md
+++ b/README.md
@@ -145,12 +145,16 @@ done
 
 ### Module version constraints
 
-The `-version-constraints` flag lets you specify a range of acceptable versions for modules.
+The `-version-constraints-semver` flag lets you specify a range of acceptable semver versions for modules.
 It expects a specially formatted string containing one or more conditions, which are separated by commas.
 The syntax is similar to the [Terraform Version Constraint Syntax](https://www.terraform.io/docs/language/expressions/version-constraints.html#version-constraint-syntax).
 
-In order to exclude all SemVer pre-releases, you can e.g. use `-version-constraints=">=v0"`, which will instruct the boring-registry cli to only upload non-pre-releases to the registry.
-This would for example allow you to prevent 
+In order to exclude all SemVer pre-releases, you can e.g. use `-version-constraints-semver=">=v0"`, which will instruct the boring-registry cli to only upload non-pre-releases to the registry.
+This would for example be useful to restrict CI to only publish releases from the `main` branch.
+
+The `-version-constraints-regex` flag lets you specify a regex that module versions have to match.
+In order to only match pre-releases, you can e.g. use `-version-constraints-regex="^[0-9]+\.[0-9]+\.[0-9]+-|\d*[a-zA-Z-][0-9a-zA-Z-]*$"`.
+This would for example be useful to prevent publishing releases from non-`main` branches, while allowing pre-releases to test out e.g. pull-requests.
 
 ## Help output
 
@@ -305,10 +309,14 @@ FLAGS
   -type=...
   BORING_REGISTRY_TYPE=...
   Registry type to use (currently only "s3" and "gcs" is supported).
-  
-  -version-constraints=...
-  BORING_REGISTRY_VERSION_CONSTRAINTS=...
-  Limit the module versions that are eligible for upload with version constraints. The version string has to be formatted as a string literal containing one or more conditions, which are separated by commas.
+
+  -version-constraints-regex=...
+  BORING_REGISTRY_VERSION_CONSTRAINTS_REGEX=...
+  Limit the module versions that are eligible for upload with a regex that a version has to match. Can be combined with the -version-constraints-semver flag.
+
+  -version-constraints-semver=...
+  BORING_REGISTRY_VERSION_CONSTRAINTS_SEMVER=...
+  Limit the module versions that are eligible for upload with version constraints. The version string has to be formatted as a string literal containing one or more conditions, which are separated by commas. Can be combined with the -version-constrained-regex flag.
 ```
 
 # Roadmap

--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ FLAGS
   
   -version-constraints=...
   BORING_REGISTRY_VERSION_CONSTRAINTS=...
-  Limit the module versions that are eligible for upload with version constraints.
+  Limit the module versions that are eligible for upload with version constraints. The version string has to be formatted as a string literal containing one or more conditions, which are separated by commas.
 ```
 
 # Roadmap

--- a/internal/cli/uploadcmd/archive.go
+++ b/internal/cli/uploadcmd/archive.go
@@ -101,7 +101,7 @@ func archiveModule(root string) (io.Reader, error) {
 	buf := new(bytes.Buffer)
 	// ensure the src actually exists before trying to tar it
 	if _, err := os.Stat(root); err != nil {
-		return buf, fmt.Errorf("Unable to tar files - %v", err.Error())
+		return buf, fmt.Errorf("unable to tar files - %v", err.Error())
 	}
 
 	gw := gzip.NewWriter(buf)
@@ -143,7 +143,7 @@ func archiveModule(root string) (io.Reader, error) {
 			return err
 		}
 
-		// manually close here after each file operation; defering would cause each file close
+		// manually close here after each file operation; deferring would cause each file close
 		// to wait until all operations have completed.
 		data.Close()
 
@@ -165,7 +165,7 @@ func (c *Config) meetsConstraints(spec *module.Spec) (bool, error) {
 		return false, err
 	}
 
-	v, err := version.NewVersion(spec.Metadata.Version)
+	v, err := version.NewSemver(spec.Metadata.Version)
 	if err != nil {
 		return false, err
 	}

--- a/internal/cli/uploadcmd/archive.go
+++ b/internal/cli/uploadcmd/archive.go
@@ -156,8 +156,13 @@ func archiveModule(root string) (io.Reader, error) {
 // meetsConstraints checks whether a module version matches the version constraints - if there are any.
 // Returns an unrecoverable error if there's an internal error. Otherwise it returns a boolean indicating if the module meets the constraints
 func (c *Config) meetsConstraints(spec *module.Spec) (bool, error) {
-	if c.VersionConstraints == nil {
+	if c.VersionConstraints == "" {
 		return true, nil
+	}
+
+	constraints, err := version.NewConstraint(c.VersionConstraints)
+	if err != nil {
+		return false, err
 	}
 
 	v, err := version.NewVersion(spec.Metadata.Version)
@@ -165,5 +170,5 @@ func (c *Config) meetsConstraints(spec *module.Spec) (bool, error) {
 		return false, err
 	}
 
-	return c.VersionConstraints.Check(v), nil
+	return constraints.Check(v), nil
 }

--- a/internal/cli/uploadcmd/upload.go
+++ b/internal/cli/uploadcmd/upload.go
@@ -77,8 +77,7 @@ func (c *Config) Exec(ctx context.Context, args []string) error {
 		return flag.ErrHelp
 	}
 
-	// TODO(oliviermichaelis): use errors.Is(err, os.ErrNotExist
-	if _, err := os.Stat(args[0]); os.IsNotExist(err) {
+	if _, err := os.Stat(args[0]); errors.Is(err, os.ErrNotExist) {
 		return err
 	}
 

--- a/internal/cli/uploadcmd/upload.go
+++ b/internal/cli/uploadcmd/upload.go
@@ -105,7 +105,7 @@ func New(config *rootcmd.Config) *ffcli.Command {
 	fs.StringVar(&cfg.S3Region, "s3-region", "", "Region of the S3 bucket when using the S3 registry type")
 	fs.StringVar(&cfg.GCSBucket, "gcs-bucket", "", "Bucket to use when using the GCS registry type")
 	fs.StringVar(&cfg.GCSPrefix, "gcs-prefix", "", "Prefix to use when using the GCS registry type")
-	fs.StringVar(&flagVersionConstraints, "version-constraints", "", "Limit the versions that are eligible for uploads with version constraints")
+	fs.StringVar(&flagVersionConstraints, "version-constraints", "", "Limit the module versions that are eligible for upload with version constraints")
 	fs.BoolVar(&cfg.UploadRecursive, "recursive", true, "Recursively traverse <dir> and upload all modules in subdirectories")
 	fs.BoolVar(&cfg.IgnoreExistingModule, "ignore-existing", true, "Ignore already existing modules. If set to false upload will fail immediately if a module already exists in that version")
 

--- a/internal/cli/uploadcmd/upload.go
+++ b/internal/cli/uploadcmd/upload.go
@@ -105,7 +105,7 @@ func New(config *rootcmd.Config) *ffcli.Command {
 	fs.StringVar(&cfg.S3Region, "s3-region", "", "Region of the S3 bucket when using the S3 registry type")
 	fs.StringVar(&cfg.GCSBucket, "gcs-bucket", "", "Bucket to use when using the GCS registry type")
 	fs.StringVar(&cfg.GCSPrefix, "gcs-prefix", "", "Prefix to use when using the GCS registry type")
-	fs.StringVar(&flagVersionConstraints, "version-constraints", "", "Limit the module versions that are eligible for upload with version constraints")
+	fs.StringVar(&flagVersionConstraints, "version-constraints", "", "Limit the module versions that are eligible for upload with version constraints. The version string has to be formatted as a string literal containing one or more conditions, which are separated by commas")
 	fs.BoolVar(&cfg.UploadRecursive, "recursive", true, "Recursively traverse <dir> and upload all modules in subdirectories")
 	fs.BoolVar(&cfg.IgnoreExistingModule, "ignore-existing", true, "Ignore already existing modules. If set to false upload will fail immediately if a module already exists in that version")
 

--- a/internal/cli/uploadcmd/upload.go
+++ b/internal/cli/uploadcmd/upload.go
@@ -15,10 +15,6 @@ import (
 	"github.com/peterbourgon/ff/v3/ffcli"
 )
 
-var (
-	flagVersionConstraints string
-)
-
 type Config struct {
 	*rootcmd.Config
 
@@ -35,8 +31,7 @@ type Config struct {
 	TelemetryListenAddress string
 	UploadRecursive        bool
 	IgnoreExistingModule   bool
-
-	VersionConstraints version.Constraints
+	VersionConstraints string
 }
 
 func (c *Config) Exec(ctx context.Context, args []string) error {
@@ -82,9 +77,8 @@ func (c *Config) Exec(ctx context.Context, args []string) error {
 	}
 
 	// Validate the version constraint
-	if flagVersionConstraints != "" {
-		var err error
-		if c.VersionConstraints, err = version.NewConstraint(flagVersionConstraints); err != nil {
+	if c.VersionConstraints != "" {
+		if _, err := version.NewConstraint(c.VersionConstraints); err != nil {
 			return err
 		}
 	}
@@ -104,7 +98,7 @@ func New(config *rootcmd.Config) *ffcli.Command {
 	fs.StringVar(&cfg.S3Region, "s3-region", "", "Region of the S3 bucket when using the S3 registry type")
 	fs.StringVar(&cfg.GCSBucket, "gcs-bucket", "", "Bucket to use when using the GCS registry type")
 	fs.StringVar(&cfg.GCSPrefix, "gcs-prefix", "", "Prefix to use when using the GCS registry type")
-	fs.StringVar(&flagVersionConstraints, "version-constraints", "", "Limit the module versions that are eligible for upload with version constraints. The version string has to be formatted as a string literal containing one or more conditions, which are separated by commas")
+	fs.StringVar(&cfg.VersionConstraints, "version-constraints", "", "Limit the module versions that are eligible for upload with version constraints. The version string has to be formatted as a string literal containing one or more conditions, which are separated by commas")
 	fs.BoolVar(&cfg.UploadRecursive, "recursive", true, "Recursively traverse <dir> and upload all modules in subdirectories")
 	fs.BoolVar(&cfg.IgnoreExistingModule, "ignore-existing", true, "Ignore already existing modules. If set to false upload will fail immediately if a module already exists in that version")
 

--- a/pkg/module/parser.go
+++ b/pkg/module/parser.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"errors"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
@@ -49,6 +50,10 @@ func (s *Spec) Validate() error {
 	}
 
 	return result.ErrorOrNil()
+}
+
+func (s *Spec) Name() string {
+	return fmt.Sprintf("%s/%s/%s/%s", s.Metadata.Namespace, s.Metadata.Name, s.Metadata.Provider, s.Metadata.Version)
 }
 
 // ParseFile parses a module spec file.


### PR DESCRIPTION
This PR adds a `-version-constraints` subcommand to the upload subcommand. Its intention is to fix #6 .
Let me know if there is a better place in the code for this functionality - I was thinking a lot about it but am not entirely happy about it...
Also let me know if I should a dedicated section in the `README.md`.

Thanks!