### PR TITLE
build: bump go to 1.16

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v2
       with:
-        go-version: ^1.15
+        go-version: ^1.16
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/goreleaser.yml
+++ b/.github/workflows/goreleaser.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v2
         with:
-          go-version: ^1.15
+          go-version: ^1.16
 
       - name: Checkout
         uses: actions/checkout@v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15 AS build
+FROM golang:1.16 AS build
 
 ENV BASEDIR /go/src/github.com/TierMobility/boring-registry
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/TierMobility/boring-registry
 
-go 1.14
+go 1.16
 
 require (
 	cloud.google.com/go v0.66.0


### PR DESCRIPTION
This PR intends to change the go version to the latest stable version
