### PR TITLE
docker: added go mod vendor

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR ${BASEDIR}
 
 ADD . ${BASEDIR}
 
+RUN go mod vendor
 RUN go install -mod=vendor github.com/TierMobility/boring-registry/cmd/boring-registry/...
 
 FROM gcr.io/distroless/base:nonroot


### PR DESCRIPTION
I ran into build problems like:

```shell
docker build .
[+] Building 1.3s (10/11)
 => [internal] load build definition from Dockerfile             0.0s
 => => transferring dockerfile: 498B                             0.0s
 => [internal] load .dockerignore                                0.0s
 => => transferring context: 2B                                  0.0s
 => [internal] load metadata for gcr.io/distroless/base:nonroot  0.4s
 => [internal] load metadata for docker.io/library/golang:1.16   0.6s
 => [build 1/4] FROM docker.io/library/golang:1.16@sha256:0056b  0.0s
 => [stage-1 1/2] FROM gcr.io/distroless/base:nonroot@sha256:a7  0.0s
 => [internal] load build context                                0.1s
 => => transferring context: 32.10kB                             0.1s
 => CACHED [build 2/4] WORKDIR /go/src/github.com/TierMobility/  0.0s
 => [build 3/4] ADD . /go/src/github.com/TierMobility/boring-re  0.2s
 => ERROR [build 4/4] RUN go install -mod=vendor github.com/Tie  0.3s
------
 > [build 4/4] RUN go install -mod=vendor github.com/TierMobility/boring-registry/cmd/boring-registry/...:
#8 0.292 go: inconsistent vendoring in /go/src/github.com/TierMobility/boring-registry:
#8 0.292 	cloud.google.com/go@v0.66.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	cloud.google.com/go/storage@v1.12.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/aws/aws-sdk-go@v1.35.34: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/fatih/color@v1.7.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/go-kit/kit@v0.10.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/googleapis/gax-go@v1.0.3: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/gorilla/mux@v1.8.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/hashicorp/go-multierror@v1.1.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/hashicorp/go-version@v1.2.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/hashicorp/hcl@v1.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/oklog/run@v1.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/peterbourgon/ff/v3@v3.0.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/pkg/errors@v0.9.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/prometheus/client_golang@v1.8.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	github.com/stretchr/testify@v1.6.1: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	golang.org/x/oauth2@v0.0.0-20200902213428-5d25da1a8d43: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	golang.org/x/sys@v0.0.0-20210915083310-ed5796bab164: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	google.golang.org/api@v0.32.0: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	google.golang.org/genproto@v0.0.0-20200921151605-7abf4a1a14d5: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292 	gopkg.in/yaml.v3@v3.0.0-20200615113413-eeeca48fe776: is explicitly required in go.mod, but not marked as explicit in vendor/modules.txt
#8 0.292
#8 0.292 	To ignore the vendor directory, use -mod=readonly or -mod=mod.
#8 0.292 	To sync the vendor directory, run:
#8 0.292 		go mod vendor
------
executor failed running [/bin/sh -c go install -mod=vendor github.com/TierMobility/boring-registry/cmd/boring-registry/...]: exit code: 1
```

This should fix it.