### PR TITLE
Add Provider Protocol support

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,10 +4,12 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path"
 	"strings"
 	"time"
 
 	"github.com/TierMobility/boring-registry/pkg/module"
+	"github.com/TierMobility/boring-registry/pkg/provider"
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"
 	"github.com/spf13/cobra"
@@ -140,7 +142,7 @@ func bindFlags(cmd *cobra.Command, v *viper.Viper) {
 
 func setupS3ModuleStorage() (module.Storage, error) {
 	return module.NewS3Storage(flagS3Bucket,
-		module.WithS3StorageBucketPrefix(flagS3Prefix),
+		module.WithS3StorageBucketPrefix(path.Join(flagS3Prefix, "modules")),
 		module.WithS3StorageBucketRegion(flagS3Region),
 		module.WithS3StorageBucketEndpoint(flagS3Endpoint),
 		module.WithS3StoragePathStyle(flagS3PathStyle),
@@ -149,9 +151,26 @@ func setupS3ModuleStorage() (module.Storage, error) {
 
 func setupGCSModuleStorage() (module.Storage, error) {
 	return module.NewGCSStorage(flagGCSBucket,
-		module.WithGCSStorageBucketPrefix(flagGCSPrefix),
+		module.WithGCSStorageBucketPrefix(path.Join(flagGCSPrefix, "modules")),
 		module.WithGCSStorageSignedURL(flagGCSSignedURL),
 		module.WithGCSServiceAccount(flagGCSServiceAccount),
 		module.WithGCSSignedUrlExpiry(int64(flagGCSSignedURLExpiry.Seconds())),
+	)
+}
+
+func setupS3ProviderStorage() (provider.Storage, error) {
+	return provider.NewS3Storage(flagS3Bucket,
+		provider.WithS3StorageBucketPrefix(path.Join(flagS3Prefix, "providers")),
+		provider.WithS3StorageBucketRegion(flagS3Region),
+		provider.WithS3StorageBucketEndpoint(flagS3Endpoint),
+		provider.WithS3StoragePathStyle(flagS3PathStyle),
+	)
+}
+
+func setupGCSProviderStorage() (provider.Storage, error) {
+	return provider.NewGCSStorage(flagGCSBucket,
+		provider.WithGCSStorageBucketPrefix(path.Join(flagGCSPrefix, "providers")),
+		provider.WithGCSServiceAccount(flagGCSServiceAccount),
+		provider.WithGCSSignedUrlExpiry(int64(flagGCSSignedURLExpiry.Seconds())),
 	)
 }

--- a/pkg/auth/auth.go
+++ b/pkg/auth/auth.go
@@ -12,24 +12,19 @@ import (
 func Middleware(keys ...string) endpoint.Middleware {
 	return func(next endpoint.Endpoint) endpoint.Endpoint {
 		return func(ctx context.Context, request interface{}) (interface{}, error) {
-			// If we didn't provide any API keys we stop early here.
 			if len(keys) < 1 {
 				return next(ctx, request)
 			}
 
-			found := false
 			for _, key := range keys {
 				key := fmt.Sprintf("Bearer %s", key)
 				if key == ctx.Value(httptransport.ContextKeyRequestAuthorization) {
-					found = true
+					return next(ctx, request)
 				}
 			}
 
-			if !found {
-				return nil, ErrInvalidKey
-			}
+			return nil, ErrInvalidKey
 
-			return next(ctx, request)
 		}
 	}
 }

--- a/pkg/provider/collection.go
+++ b/pkg/provider/collection.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"fmt"
+)
+
+type Collection struct {
+	m map[string]ProviderVersion
+}
+
+func NewCollection() *Collection {
+	return &Collection{
+		m: make(map[string]ProviderVersion),
+	}
+}
+
+func (s *Collection) List() []ProviderVersion {
+	var out []ProviderVersion
+
+	for _, provider := range s.m {
+		out = append(out, provider)
+	}
+
+	return out
+}
+
+func (s *Collection) Add(provider Provider) {
+	id := fmt.Sprintf("%s/%s/%s", provider.Namespace, provider.Name, provider.Version)
+
+	if _, ok := s.m[id]; !ok {
+		s.m[id] = ProviderVersion{
+			Namespace: provider.Namespace,
+			Name:      provider.Name,
+			Version:   provider.Version,
+		}
+	}
+
+	ver := s.m[id]
+	ver.Platforms = append(ver.Platforms, Platform{OS: provider.OS, Arch: provider.Arch})
+	s.m[id] = ver
+}

--- a/pkg/provider/endpoint.go
+++ b/pkg/provider/endpoint.go
@@ -1,0 +1,86 @@
+package provider
+
+import (
+	"context"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+type listRequest struct {
+	namespace string
+	name      string
+}
+
+type listResponse struct {
+	Versions []listResponseVersion `json:"versions,omitempty"`
+}
+
+type listResponseVersion struct {
+	Version   string     `json:"version,omitempty"`
+	Platforms []Platform `json:"platforms,omitempty"`
+}
+
+func listEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(listRequest)
+
+		res, err := svc.ListProviderVersions(ctx, req.namespace, req.name)
+		if err != nil {
+			return nil, err
+		}
+
+		var versions []listResponseVersion
+
+		for _, provider := range res {
+			versions = append(versions, listResponseVersion{
+				Version:   provider.Version,
+				Platforms: provider.Platforms,
+			})
+		}
+
+		return listResponse{
+			Versions: versions,
+		}, nil
+	}
+}
+
+type downloadRequest struct {
+	namespace string
+	name      string
+	version   string
+	os        string
+	arch      string
+}
+
+type downloadResponse struct {
+	OS                  string      `json:"os"`
+	Arch                string      `json:"arch"`
+	Filename            string      `json:"filename"`
+	DownloadURL         string      `json:"download_url"`
+	Shasum              string      `json:"shasum"`
+	ShasumsURL          string      `json:"shasums_url"`
+	ShasumsSignatureURL string      `json:"shasums_signature_url"`
+	SigningKeys         SigningKeys `json:"signing_keys"`
+}
+
+func downloadEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req := request.(downloadRequest)
+
+		res, err := svc.GetProvider(ctx, req.namespace, req.name, req.version, req.os, req.arch)
+		if err != nil {
+			return nil, err
+		}
+
+		return downloadResponse{
+			OS:                  res.OS,
+			Arch:                res.Arch,
+			DownloadURL:         res.DownloadURL,
+			Filename:            res.Filename,
+			Shasum:              res.Shasum,
+			SigningKeys:         res.SigningKeys,
+			ShasumsURL:          res.SHASumsURL,
+			ShasumsSignatureURL: res.SHASumsSignatureURL,
+		}, nil
+	}
+}

--- a/pkg/provider/errors.go
+++ b/pkg/provider/errors.go
@@ -1,0 +1,15 @@
+package provider
+
+import "errors"
+
+// Storage errors.
+var (
+	ErrAlreadyExists = errors.New("provider already exists")
+	ErrNotFound      = errors.New("failed to locate provider")
+	ErrListFailed    = errors.New("failed to list provider versions")
+)
+
+// Transport errors.
+var (
+	ErrVarMissing = errors.New("variable missing")
+)

--- a/pkg/provider/middleware.go
+++ b/pkg/provider/middleware.go
@@ -1,0 +1,66 @@
+package provider
+
+import (
+	"context"
+	"time"
+
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+)
+
+// Middleware is a Service middleware.
+type Middleware func(Service) Service
+
+type loggingMiddleware struct {
+	next   Service
+	logger log.Logger
+}
+
+// LoggingMiddleware is a logging Service middleware.
+func LoggingMiddleware(logger log.Logger) Middleware {
+	return func(next Service) Service {
+		return &loggingMiddleware{
+			logger: logger,
+			next:   next,
+		}
+	}
+}
+
+func (mw loggingMiddleware) ListProviderVersions(ctx context.Context, namespace, name string) (providers []ProviderVersion, err error) {
+	defer func(begin time.Time) {
+		logger := level.Info(mw.logger)
+		if err != nil {
+			logger = level.Error(mw.logger)
+		}
+
+		_ = logger.Log(
+			"op", "ListProviderVersions",
+			"namespace", namespace,
+			"name", name,
+			"took", time.Since(begin),
+			"err", err,
+		)
+
+	}(time.Now())
+
+	return mw.next.ListProviderVersions(ctx, namespace, name)
+}
+
+func (mw loggingMiddleware) GetProvider(ctx context.Context, namespace, name, version, os, arch string) (provider Provider, err error) {
+	defer func(begin time.Time) {
+		logger := level.Info(mw.logger)
+		if err != nil {
+			logger = level.Error(mw.logger)
+		}
+
+		_ = logger.Log(
+			"op", "GetProvider",
+			"provider", provider.ID(true),
+			"took", time.Since(begin),
+			"err", err,
+		)
+
+	}(time.Now())
+
+	return mw.next.GetProvider(ctx, namespace, name, version, os, arch)
+}

--- a/pkg/provider/provider.go
+++ b/pkg/provider/provider.go
@@ -1,0 +1,90 @@
+package provider
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Provider represents Terraform provider metadata.
+type Provider struct {
+	Namespace           string      `json:"namespace,omitempty"`
+	Name                string      `json:"name,omitempty"`
+	Version             string      `json:"version,omitempty"`
+	OS                  string      `json:"os,omitempty"`
+	Arch                string      `json:"arch,omitempty"`
+	Filename            string      `json:"filename,omitempty"`
+	DownloadURL         string      `json:"download_url,omitempty"`
+	Shasum              string      `json:"shasum,omitempty"`
+	SHASumsURL          string      `json:"shasums_url,omitempty"`
+	SHASumsSignatureURL string      `json:"shasums_signature_url,omitempty"`
+	SigningKeys         SigningKeys `json:"signing_keys,omitempty"`
+	Platforms           []Platform  `json:"platforms,omitempty"`
+}
+
+// ID returns the module metadata in a compact format.
+func (p *Provider) ID(version bool) string {
+	id := fmt.Sprintf("namespace=%s/name=%s", p.Namespace, p.Name)
+	if version {
+		id = fmt.Sprintf("%s/version=%s", id, p.Version)
+	}
+
+	return id
+}
+
+func (p *Provider) Valid() bool {
+	return p.Name != "" &&
+		p.Arch != "" &&
+		p.Namespace != "" &&
+		p.OS != "" &&
+		p.Version != ""
+}
+
+type ProviderVersion struct {
+	Namespace string     `json:"namespace,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	Version   string     `json:"version,omitempty"`
+	Platforms []Platform `json:"platforms,omitempty"`
+}
+
+type Platform struct {
+	OS   string `json:"os,omitempty"`
+	Arch string `json:"arch,omitempty"`
+}
+
+type GPGPublicKey struct {
+	KeyID      string `json:"key_id,omitempty"`
+	ASCIIArmor string `json:"ascii_armor,omitempty"`
+	Source     string `json:"source,omitempty"`
+	SourceURL  string `json:"source_url,omitempty"`
+}
+
+type SigningKeys struct {
+	GPGPublicKeys []GPGPublicKey `json:"gpg_public_keys,omitempty"`
+}
+
+func Parse(v string) (Provider, error) {
+	m := make(map[string]string)
+
+	for _, part := range strings.Split(v, "/") {
+		parts := strings.SplitN(part, "=", 2)
+		if len(parts) != 2 {
+			continue
+		}
+
+		m[parts[0]] = parts[1]
+	}
+
+	provider := Provider{
+		Namespace: m["namespace"],
+		Name:      m["name"],
+		Version:   m["version"],
+		OS:        m["os"],
+		Arch:      m["arch"],
+	}
+
+	if !provider.Valid() {
+		return Provider{}, fmt.Errorf("%q is not a valid path", v)
+	}
+
+	return provider, nil
+}

--- a/pkg/provider/provider_test.go
+++ b/pkg/provider/provider_test.go
@@ -1,0 +1,53 @@
+package provider
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestPath(t *testing.T) {
+	t.Parallel()
+	assert := assert.New(t)
+
+	testCases := []struct {
+		name          string
+		path          string
+		expected      *Provider
+		expectedError bool
+	}{
+		{
+			name:          "valid path",
+			path:          "namespace=tier/name=s3/version=1.0.0/os=darwin/arch=amd64",
+			expectedError: false,
+			expected: &Provider{
+				Name:      "s3",
+				Namespace: "tier",
+				Version:   "1.0.0",
+				OS:        "darwin",
+				Arch:      "amd64",
+			},
+		},
+		{
+			name:          "partial path",
+			path:          "namespace=tier/name=foo/version=1.0.0/os=darwin",
+			expectedError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			path, err := Parse(tc.path)
+			if tc.expectedError {
+				assert.Error(err)
+			} else {
+				assert.NoError(err)
+			}
+
+			if tc.expected != nil {
+				assert.Equal(*tc.expected, path)
+			}
+		})
+	}
+}

--- a/pkg/provider/service.go
+++ b/pkg/provider/service.go
@@ -1,0 +1,41 @@
+package provider
+
+import (
+	"context"
+)
+
+// Service implements the Provider Registry Protocol.
+// For more information see: https://www.terraform.io/docs/internals/provider-registry-protocol.html.
+type Service interface {
+	GetProvider(ctx context.Context, namespace, name, version, os, arch string) (Provider, error)
+	ListProviderVersions(ctx context.Context, namespace, name string) ([]ProviderVersion, error)
+}
+
+type service struct {
+	storage Storage
+}
+
+// NewService returns a fully initialized Service.
+func NewService(storage Storage) Service {
+	return &service{
+		storage: storage,
+	}
+}
+
+func (s *service) GetProvider(ctx context.Context, namespace, name, version, os, arch string) (Provider, error) {
+	res, err := s.storage.GetProvider(ctx, namespace, name, version, os, arch)
+	if err != nil {
+		return Provider{}, err
+	}
+
+	return res, nil
+}
+
+func (s *service) ListProviderVersions(ctx context.Context, namespace, name string) ([]ProviderVersion, error) {
+	res, err := s.storage.ListProviderVersions(ctx, namespace, name)
+	if err != nil {
+		return nil, err
+	}
+
+	return res, nil
+}

--- a/pkg/provider/storage.go
+++ b/pkg/provider/storage.go
@@ -1,0 +1,51 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"path"
+)
+
+// Storage represents the Storage of Terraform providers.
+type Storage interface {
+	GetProvider(ctx context.Context, namespace, name, version, os, arch string) (Provider, error)
+	ListProviderVersions(ctx context.Context, namespace, name string) ([]ProviderVersion, error)
+}
+
+func storagePrefix(prefix, namespace, name string) string {
+	return path.Join(
+		prefix,
+		fmt.Sprintf("namespace=%s", namespace),
+		fmt.Sprintf("name=%s", name),
+	)
+}
+
+func storagePath(prefix, namespace, name, version, os, arch string) string {
+	return path.Join(
+		prefix,
+		fmt.Sprintf("namespace=%s", namespace),
+		fmt.Sprintf("name=%s", name),
+		fmt.Sprintf("version=%s", version),
+		fmt.Sprintf("os=%s", os),
+		fmt.Sprintf("arch=%s", arch),
+		fmt.Sprintf("terraform-provider-%s_%s_%s_%s.zip", name, version, os, arch),
+	)
+}
+
+func shasumsPath(prefix, namespace, name, version string) string {
+	return path.Join(
+		prefix,
+		fmt.Sprintf("namespace=%s", namespace),
+		fmt.Sprintf("name=%s", name),
+		fmt.Sprintf("version=%s", version),
+		fmt.Sprintf("terraform-provider-%s_%s_SHA256SUMS", name, version),
+	)
+}
+
+func signingKeysPath(prefix, namespace string) string {
+	return path.Join(
+		prefix,
+		fmt.Sprintf("namespace=%s", namespace),
+		"signing-keys.json",
+	)
+}

--- a/pkg/provider/storage_gcs.go
+++ b/pkg/provider/storage_gcs.go
@@ -1,0 +1,235 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"path"
+	"time"
+
+	credentials "cloud.google.com/go/iam/credentials/apiv1"
+	"cloud.google.com/go/storage"
+	"github.com/pkg/errors"
+	"golang.org/x/oauth2/google"
+	"google.golang.org/api/iterator"
+	credentialspb "google.golang.org/genproto/googleapis/iam/credentials/v1"
+)
+
+type GCSStorage struct {
+	sc              *storage.Client
+	bucket          string
+	bucketPrefix    string
+	signedURLExpiry int64
+	serviceAccount  string
+}
+
+func (s *GCSStorage) ListProviderVersions(ctx context.Context, namespace, name string) ([]ProviderVersion, error) {
+	prefix := storagePrefix(s.bucketPrefix, namespace, name)
+
+	query := &storage.Query{
+		Prefix: fmt.Sprintf("%s/", prefix),
+	}
+
+	collection := NewCollection()
+	it := s.sc.Bucket(s.bucket).Objects(ctx, query)
+
+	for {
+		attrs, err := it.Next()
+		if err == iterator.Done {
+			break
+		}
+		if err != nil {
+			return nil, err
+		}
+
+		provider, err := Parse(attrs.Name)
+		if err != nil {
+			continue
+		}
+
+		collection.Add(provider)
+	}
+
+	result := collection.List()
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no provider versions found for %s/%s", namespace, name)
+	}
+
+	return result, nil
+}
+
+func (s *GCSStorage) GetProvider(ctx context.Context, namespace, name, version, os, arch string) (Provider, error) {
+	var (
+		pathPkg         = storagePath(s.bucketPrefix, namespace, name, version, os, arch)
+		pathSha         = shasumsPath(s.bucketPrefix, namespace, name, version)
+		pathSig         = fmt.Sprintf("%s.sig", pathSha)
+		pathSigningKeys = signingKeysPath(s.bucketPrefix, namespace)
+	)
+
+	shasumsURL, err := s.signedURL(pathSha)
+	if err != nil {
+		return Provider{}, errors.Wrap(err, pathSig)
+	}
+
+	signatureURL, err := s.signedURL(pathSig)
+	if err != nil {
+		return Provider{}, err
+	}
+
+	zipURL, err := s.signedURL(pathPkg)
+	if err != nil {
+		return Provider{}, err
+	}
+
+	signingKeysRaw, err := s.download(pathSigningKeys)
+	if err != nil {
+		return Provider{}, errors.Wrap(err, pathSigningKeys)
+	}
+
+	var signingKey GPGPublicKey
+	if err := json.Unmarshal(signingKeysRaw, &signingKey); err != nil {
+		return Provider{}, err
+	}
+
+	shasums, err := s.download(pathSha)
+	if err != nil {
+		return Provider{}, err
+	}
+
+	shasum, err := readSHASums(bytes.NewReader(shasums), path.Base(pathPkg))
+	if err != nil {
+		return Provider{}, err
+	}
+
+	return Provider{
+		Namespace:           namespace,
+		Filename:            path.Base(pathPkg),
+		Name:                name,
+		Version:             version,
+		OS:                  os,
+		Arch:                arch,
+		Shasum:              shasum,
+		DownloadURL:         zipURL,
+		SHASumsURL:          shasumsURL,
+		SHASumsSignatureURL: signatureURL,
+		SigningKeys: SigningKeys{
+			GPGPublicKeys: []GPGPublicKey{
+				signingKey,
+			},
+		},
+	}, nil
+}
+
+func (s *GCSStorage) download(path string) ([]byte, error) {
+	r, err := s.sc.Bucket(s.bucket).Object(path).NewReader(context.Background())
+	if err != nil {
+		return nil, err
+	}
+	defer r.Close()
+
+	data, err := ioutil.ReadAll(r)
+	if err != nil {
+		return nil, err
+	}
+
+	return data, nil
+}
+
+func (s *GCSStorage) signedURL(v string) (string, error) {
+	ctx := context.Background()
+	//https://godoc.org/golang.org/x/oauth2/google#DefaultClient
+	cred, err := google.FindDefaultCredentials(ctx, "cloud-platform")
+	if err != nil {
+		return "", fmt.Errorf("google.FindDefaultCredentials: %v", err)
+	}
+
+	var url string
+	if s.serviceAccount != "" {
+		// needs Service Account Token Creator role
+		c, err := credentials.NewIamCredentialsClient(ctx)
+		if err != nil {
+			return "", fmt.Errorf("credentials.NewIamCredentialsClient: %v", err)
+		}
+
+		url, err = storage.SignedURL(s.bucket, v, &storage.SignedURLOptions{
+			Scheme:         storage.SigningSchemeV4,
+			Method:         "GET",
+			GoogleAccessID: s.serviceAccount,
+			Expires:        time.Now().Add(time.Duration(s.signedURLExpiry) * time.Second),
+			SignBytes: func(b []byte) ([]byte, error) {
+				req := &credentialspb.SignBlobRequest{
+					Payload: b,
+					Name:    s.serviceAccount,
+				}
+				resp, err := c.SignBlob(ctx, req)
+				if err != nil {
+					return nil, fmt.Errorf("storage.signedURL.SignBytes: %v", err)
+				}
+				return resp.SignedBlob, nil
+			},
+		})
+		if err != nil {
+			return "", fmt.Errorf("storage.signedURL: %v", err)
+		}
+	} else {
+		conf, err := google.JWTConfigFromJSON(cred.JSON)
+		opts := &storage.SignedURLOptions{
+			Scheme:         storage.SigningSchemeV4,
+			Method:         "GET",
+			GoogleAccessID: conf.Email,
+			PrivateKey:     conf.PrivateKey,
+			Expires:        time.Now().Add(time.Duration(s.signedURLExpiry) * time.Second),
+		}
+		url, err = storage.SignedURL(s.bucket, v, opts)
+		if err != nil {
+			return "", fmt.Errorf("storage.signedURL: %v", err)
+		}
+	}
+
+	return url, nil
+}
+
+// GCSStorageOption provides additional options for the GCSStorage.
+type GCSStorageOption func(*GCSStorage)
+
+// WithGCSStorageBucketPrefix configures the s3 storage to work under a given prefix.
+func WithGCSStorageBucketPrefix(prefix string) GCSStorageOption {
+	return func(s *GCSStorage) {
+		s.bucketPrefix = prefix
+	}
+}
+
+// WithGCSServiceAccount configures Application Default Credentials (ADC) service account email.
+func WithGCSServiceAccount(sa string) GCSStorageOption {
+	return func(s *GCSStorage) {
+		s.serviceAccount = sa
+	}
+}
+
+// WithGCSServiceAccount configures Application Default Credentials (ADC) service account email.
+func WithGCSSignedUrlExpiry(seconds int64) GCSStorageOption {
+	return func(s *GCSStorage) {
+		s.signedURLExpiry = seconds
+	}
+}
+
+func NewGCSStorage(bucket string, options ...GCSStorageOption) (Storage, error) {
+	ctx := context.Background()
+	client, err := storage.NewClient(ctx)
+	if err != nil {
+		return nil, err
+	}
+	s := &GCSStorage{
+		sc:     client,
+		bucket: bucket,
+	}
+
+	for _, option := range options {
+		option(s)
+	}
+
+	return s, nil
+}

--- a/pkg/provider/storage_s3.go
+++ b/pkg/provider/storage_s3.go
@@ -1,0 +1,250 @@
+package provider
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/pkg/errors"
+)
+
+// S3Storage is a Storage implementation backed by S3.
+type S3Storage struct {
+	s3             *s3.S3
+	downloader     *s3manager.Downloader
+	uploader       *s3manager.Uploader
+	bucket         string
+	bucketPrefix   string
+	bucketRegion   string
+	pathStyle      bool
+	bucketEndpoint string
+}
+
+// GetProvider retrieves information about a provider from the S3 storage.
+func (s *S3Storage) GetProvider(ctx context.Context, namespace, name, version, os, arch string) (Provider, error) {
+	var (
+		pathPkg         = storagePath(s.bucketPrefix, namespace, name, version, os, arch)
+		pathSha         = shasumsPath(s.bucketPrefix, namespace, name, version)
+		pathSig         = fmt.Sprintf("%s.sig", pathSha)
+		pathSigningKeys = signingKeysPath(s.bucketPrefix, namespace)
+	)
+
+	shasumsURL, err := s.presignedURL(pathSha)
+	if err != nil {
+		return Provider{}, errors.Wrap(err, pathSig)
+	}
+
+	signatureURL, err := s.presignedURL(pathSig)
+	if err != nil {
+		return Provider{}, err
+	}
+
+	zipURL, err := s.presignedURL(pathPkg)
+	if err != nil {
+		return Provider{}, err
+	}
+
+	signingKeysRaw, err := s.download(pathSigningKeys)
+	if err != nil {
+		return Provider{}, errors.Wrap(err, pathSigningKeys)
+	}
+
+	var signingKey GPGPublicKey
+	if err := json.Unmarshal(signingKeysRaw, &signingKey); err != nil {
+		return Provider{}, err
+	}
+
+	shasums, err := s.download(pathSha)
+	if err != nil {
+		return Provider{}, err
+	}
+
+	shasum, err := readSHASums(bytes.NewReader(shasums), path.Base(pathPkg))
+	if err != nil {
+		return Provider{}, err
+	}
+
+	return Provider{
+		Namespace:           namespace,
+		Filename:            path.Base(pathPkg),
+		Name:                name,
+		Version:             version,
+		OS:                  os,
+		Arch:                arch,
+		Shasum:              shasum,
+		DownloadURL:         zipURL,
+		SHASumsURL:          shasumsURL,
+		SHASumsSignatureURL: signatureURL,
+		SigningKeys: SigningKeys{
+			GPGPublicKeys: []GPGPublicKey{
+				signingKey,
+			},
+		},
+	}, nil
+}
+
+func (s *S3Storage) ListProviderVersions(ctx context.Context, namespace, name string) ([]ProviderVersion, error) {
+	input := &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(fmt.Sprintf("%s/", storagePrefix(s.bucketPrefix, namespace, name))),
+	}
+
+	collection := NewCollection()
+	fn := func(page *s3.ListObjectsV2Output, last bool) bool {
+		for _, obj := range page.Contents {
+			provider, err := Parse(*obj.Key)
+			if err != nil {
+				continue
+			}
+
+			collection.Add(provider)
+		}
+
+		return true
+	}
+
+	if err := s.s3.ListObjectsV2Pages(input, fn); err != nil {
+		return nil, errors.Wrap(ErrListFailed, err.Error())
+	}
+
+	result := collection.List()
+
+	if len(result) == 0 {
+		return nil, fmt.Errorf("no provider versions found for %s/%s", namespace, name)
+	}
+
+	return result, nil
+}
+
+func (s *S3Storage) determineBucketRegion() (string, error) {
+	region, err := s3manager.GetBucketRegionWithClient(context.Background(), s.s3, s.bucket)
+	if err != nil {
+		return "", err
+	}
+
+	return region, nil
+}
+
+// S3StorageOption provides additional options for the S3Storage.
+type S3StorageOption func(*S3Storage)
+
+// WithS3StorageBucketPrefix configures the s3 storage to work under a given prefix.
+func WithS3StorageBucketPrefix(prefix string) S3StorageOption {
+	return func(s *S3Storage) {
+		s.bucketPrefix = prefix
+	}
+}
+
+// WithS3StorageBucketRegion configures the region for a given s3 storage.
+func WithS3StorageBucketRegion(region string) S3StorageOption {
+	return func(s *S3Storage) {
+		s.bucketRegion = region
+	}
+}
+
+// WithS3StorageBucketEndpoint configures the endpoint for a given s3 storage. (needed for MINIO)
+func WithS3StorageBucketEndpoint(endpoint string) S3StorageOption {
+	return func(s *S3Storage) {
+		// default value is "", so don't set and leave to aws sdk
+		if len(endpoint) > 0 {
+			s.s3.Client.Endpoint = endpoint
+		}
+		s.bucketEndpoint = "aws sdk default"
+	}
+}
+
+// WithS3StoragePathStyle configures if Path Style is used for a given s3 storage. (needed for MINIO)
+func WithS3StoragePathStyle(pathStyle bool) S3StorageOption {
+	return func(s *S3Storage) {
+		// only set if true, default value is false but leave for aws sdk
+		if pathStyle {
+			s.s3.Client.Config.S3ForcePathStyle = &pathStyle
+		}
+		s.pathStyle = pathStyle
+	}
+}
+
+// NewS3Storage returns a fully initialized S3 storage.
+func NewS3Storage(bucket string, options ...S3StorageOption) (Storage, error) {
+	sess, err := session.NewSession()
+	if err != nil {
+		return nil, err
+	}
+
+	s := &S3Storage{
+		s3:         s3.New(sess),
+		uploader:   s3manager.NewUploader(sess),
+		downloader: s3manager.NewDownloader(sess),
+		bucket:     bucket,
+	}
+
+	for _, option := range options {
+		option(s)
+	}
+
+	if s.bucketRegion == "" {
+		region, err := s.determineBucketRegion()
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to determine bucket region")
+		}
+		s.bucketRegion = region
+	}
+
+	return s, nil
+}
+
+func (s *S3Storage) presignedURL(v string) (string, error) {
+	req, _ := s.s3.GetObjectRequest(&s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(v),
+	})
+
+	return req.Presign(15 * time.Minute)
+}
+
+func readSHASums(r io.Reader, name string) (string, error) {
+	scanner := bufio.NewScanner(r)
+
+	sha := ""
+	for scanner.Scan() {
+		parts := strings.Split(scanner.Text(), " ")
+		if len(parts) != 3 {
+			continue
+		}
+
+		if parts[2] == name {
+			sha = parts[0]
+		}
+	}
+
+	if sha == "" {
+		return "", fmt.Errorf("did not find package: %s in shasums file", name)
+	}
+
+	return sha, nil
+}
+
+func (s *S3Storage) download(path string) ([]byte, error) {
+	buf := aws.NewWriteAtBuffer([]byte{})
+
+	input := &s3.GetObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(path),
+	}
+
+	if _, err := s.downloader.Download(buf, input); err != nil {
+		return nil, errors.Wrapf(err, "failed to download: %s", path)
+	}
+
+	return buf.Bytes(), nil
+}

--- a/pkg/provider/transport.go
+++ b/pkg/provider/transport.go
@@ -1,0 +1,154 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+
+	"github.com/TierMobility/boring-registry/pkg/auth"
+	"github.com/go-kit/kit/endpoint"
+	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+)
+
+type muxVar string
+
+const (
+	varNamespace muxVar = "namespace"
+	varName      muxVar = "name"
+	varOS        muxVar = "os"
+	varArch      muxVar = "arch"
+	varVersion   muxVar = "version"
+)
+
+type header string
+
+// MakeHandler returns a fully initialized http.Handler.
+func MakeHandler(svc Service, auth endpoint.Middleware, options ...httptransport.ServerOption) http.Handler {
+	r := mux.NewRouter().StrictSlash(true)
+
+	r.Methods("GET").Path(`/{namespace}/{name}/versions`).Handler(
+		httptransport.NewServer(
+			auth(listEndpoint(svc)),
+			decodeListRequest,
+			httptransport.EncodeJSONResponse,
+			append(
+				options,
+				httptransport.ServerBefore(extractMuxVars(varNamespace, varName)),
+				httptransport.ServerBefore(extractHeaders("Authorization")),
+			)...,
+		),
+	)
+
+	r.Methods("GET").Path(`/{namespace}/{name}/{version}/download/{os}/{arch}`).Handler(
+		httptransport.NewServer(
+			auth(downloadEndpoint(svc)),
+			decodeDownloadRequest,
+			httptransport.EncodeJSONResponse,
+			append(
+				options,
+				httptransport.ServerBefore(extractMuxVars(varNamespace, varName, varOS, varArch, varVersion)),
+				httptransport.ServerBefore(extractHeaders("Authorization")),
+			)...,
+		),
+	)
+
+	return r
+}
+
+func decodeListRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	namespace, ok := ctx.Value(varNamespace).(string)
+	if !ok {
+		return nil, errors.Wrap(ErrVarMissing, "namespace")
+	}
+
+	name, ok := ctx.Value(varName).(string)
+	if !ok {
+		return nil, errors.Wrap(ErrVarMissing, "name")
+	}
+
+	return listRequest{
+		namespace: namespace,
+		name:      name,
+	}, nil
+}
+
+func decodeDownloadRequest(ctx context.Context, r *http.Request) (interface{}, error) {
+	namespace, ok := ctx.Value(varNamespace).(string)
+	if !ok {
+		return nil, errors.Wrap(ErrVarMissing, "namespace")
+	}
+
+	name, ok := ctx.Value(varName).(string)
+	if !ok {
+		return nil, errors.Wrap(ErrVarMissing, "name")
+	}
+
+	version, ok := ctx.Value(varVersion).(string)
+	if !ok {
+		return nil, errors.Wrap(ErrVarMissing, "version")
+	}
+
+	os, ok := ctx.Value(varOS).(string)
+	if !ok {
+		return nil, errors.Wrap(ErrVarMissing, "os")
+	}
+
+	arch, ok := ctx.Value(varArch).(string)
+	if !ok {
+		return nil, errors.Wrap(ErrVarMissing, "arch")
+	}
+
+	return downloadRequest{
+		namespace: namespace,
+		name:      name,
+		version:   version,
+		os:        os,
+		arch:      arch,
+	}, nil
+}
+
+// ErrorEncoder translates domain specific errors to HTTP status codes.
+func ErrorEncoder(_ context.Context, err error, w http.ResponseWriter) {
+	switch errors.Cause(err) {
+	case ErrVarMissing:
+		w.WriteHeader(http.StatusBadRequest)
+	case auth.ErrInvalidKey:
+		w.WriteHeader(http.StatusUnauthorized)
+	default:
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	_ = json.NewEncoder(w).Encode(struct {
+		Error string `json:"error"`
+	}{
+		Error: err.Error(),
+	})
+}
+
+func extractHeaders(keys ...header) httptransport.RequestFunc {
+	return func(ctx context.Context, r *http.Request) context.Context {
+		for _, k := range keys {
+			if v := r.Header.Get(string(k)); v != "" {
+				ctx = context.WithValue(ctx, k, v)
+			}
+		}
+
+		return ctx
+	}
+}
+
+func extractMuxVars(keys ...muxVar) httptransport.RequestFunc {
+	return func(ctx context.Context, r *http.Request) context.Context {
+		for _, k := range keys {
+			if v, ok := mux.Vars(r)[string(k)]; ok {
+				ctx = context.WithValue(ctx, k, v)
+			}
+		}
+
+		return ctx
+	}
+}


### PR DESCRIPTION
This changeset adds support for the Provider Registry Protocol and it unfortunately, comes with a breaking change ⚠️ :
* `--storage-s3-prefix` & `--storage-gcs-prefix` is now extended with: `${prefix}/providers` & `${prefix}/modules`. 

Example tree:
```
bucket
├── modules
│   └── namespace=tier
│       └── name=test
│           └── provider=test
│               └── version=1.0.0
└── providers
    └── namespace=tier
        └── name=test
            └── version=1.0.0
```

Will follow up with more fixes and documentation around this but this should lay the groundwork 🙂 