### PR TITLE
Match Filename by Suffix for Checksums

### DIFF
--- a/pkg/provider/storage_s3.go
+++ b/pkg/provider/storage_s3.go
@@ -1,14 +1,11 @@
 package provider
 
 import (
-	"bufio"
 	"bytes"
 	"context"
 	"encoding/json"
 	"fmt"
-	"io"
 	"path"
-	"strings"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -210,28 +207,6 @@ func (s *S3Storage) presignedURL(v string) (string, error) {
 	})
 
 	return req.Presign(15 * time.Minute)
-}
-
-func readSHASums(r io.Reader, name string) (string, error) {
-	scanner := bufio.NewScanner(r)
-
-	sha := ""
-	for scanner.Scan() {
-		parts := strings.Split(scanner.Text(), " ")
-		if len(parts) != 3 {
-			continue
-		}
-
-		if parts[2] == name {
-			sha = parts[0]
-		}
-	}
-
-	if sha == "" {
-		return "", fmt.Errorf("did not find package: %s in shasums file", name)
-	}
-
-	return sha, nil
 }
 
 func (s *S3Storage) download(path string) ([]byte, error) {


### PR DESCRIPTION
In order to get GoReleaser to upload directly to S3 in the expected format, I had to set the filename template in the expected format which resulted in something like this in the SHA256 sums.

```
c71982793689229cb3df60472274fc634c2dac6e7309c0953cff39a75be704c2  os=freebsd/arch=amd64/terraform-provider-myprovider_0.0.1_freebsd_amd64.zip
f8e3fd74a07609c7c54f693ba7c098bfec01f118cb207d2edaffbd2e48357455  os=darwin/arch=amd64/terraform-provider-myprovider_0.0.1_darwin_amd64.zip
```

Matching by suffix will preserve previous behavior and also allow it to work with a format with a folder structure such as this.

Also, I moved `readSHASums` into `storage.go` since it is used by GCP and S3.