### PR TITLE
Adds support for using gcs API URLs for provider URLs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -172,5 +172,6 @@ func setupGCSProviderStorage() (provider.Storage, error) {
 		provider.WithGCSStorageBucketPrefix(path.Join(flagGCSPrefix, "providers")),
 		provider.WithGCSServiceAccount(flagGCSServiceAccount),
 		provider.WithGCSSignedUrlExpiry(int64(flagGCSSignedURLExpiry.Seconds())),
+		provider.WithGCSUseSignedURL(flagGCSSignedURL),
 	)
 }


### PR DESCRIPTION
Hey y'all! 

First off I want to say thank you so much for putting this together, this has saved me god knows how many hours!

This PR adds support for using googleapi URLs for GCS objects instead of creating signed URLs. We have a use case for a provider that's published on a public bucket, so the additional perms for blob signing were not needed. One thing to call out is that this is a breaking change, as users that rely on blob signing will need to specify `--storage-gcs-signedurl=true` to maintain the current behavior. However, to maintain compatibility the default for providers could be set to true unless explicitly specified to be false.  