### PR TITLE
feat(core): add package for core data types and their methods

### DIFF
--- a/pkg/core/provider.go
+++ b/pkg/core/provider.go
@@ -1,0 +1,111 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	ProviderPrefix    = "terraform-provider-"
+	ProviderExtension = ".zip"
+)
+
+// Provider copied from provider.Provider
+// Provider represents Terraform provider metadata.
+type Provider struct {
+	Hostname            string      `json:"hostname,omitempty"`
+	Namespace           string      `json:"namespace,omitempty"`
+	Name                string      `json:"name,omitempty"`
+	Version             string      `json:"version,omitempty"`
+	OS                  string      `json:"os,omitempty"`
+	Arch                string      `json:"arch,omitempty"`
+	Filename            string      `json:"filename,omitempty"`
+	DownloadURL         string      `json:"download_url,omitempty"`
+	Shasum              string      `json:"shasum,omitempty"`
+	SHASumsURL          string      `json:"shasums_url,omitempty"`
+	SHASumsSignatureURL string      `json:"shasums_signature_url,omitempty"`
+	SigningKeys         SigningKeys `json:"signing_keys,omitempty"`
+	Platforms           []Platform  `json:"platforms,omitempty"`
+}
+
+func (p *Provider) ArchiveFileName() (string, error) {
+	// Validate the Provider struct
+	if p.Name == "" {
+		return "", errors.New("provider Name is empty")
+	} else if p.Version == "" {
+		return "", errors.New("provider Version is empty")
+	} else if p.OS == "" {
+		return "", errors.New("provider OS is empty")
+	} else if p.Arch == "" {
+		return "", errors.New("provider Arch is empty")
+	}
+
+	return fmt.Sprintf("%s%s_%s_%s_%s%s", ProviderPrefix, p.Name, p.Version, p.OS, p.Arch, ProviderExtension), nil
+}
+
+func (p *Provider) ShasumFileName() (string, error) {
+	if p.Name == "" {
+		return "", errors.New("provider Name is empty")
+	} else if p.Version == "" {
+		return "", errors.New("provider Version is empty")
+	}
+
+	return fmt.Sprintf("%s%s_%s_SHA256SUMS", ProviderPrefix, p.Name, p.Version), nil
+}
+
+func (p *Provider) ShasumSignatureFileName() (string, error) {
+	if p.Name == "" {
+		return "", errors.New("provider Name is empty")
+	} else if p.Version == "" {
+		return "", errors.New("provider Version is empty")
+	}
+
+	return fmt.Sprintf("%s%s_%s_SHA256SUMS.sig", ProviderPrefix, p.Name, p.Version), nil
+}
+
+func NewProviderFromArchive(filename string) (Provider, error) {
+	// Criterias for terraform archives:
+	// https://www.terraform.io/docs/registry/providers/publishing.html#manually-preparing-a-release
+	f := filepath.Base(filename) // This is just a precaution
+	trimmed := strings.TrimPrefix(f, ProviderPrefix)
+	trimmed = strings.TrimSuffix(trimmed, ProviderExtension)
+	tokens := strings.Split(trimmed, "_")
+	if len(tokens) != 4 {
+		return Provider{}, fmt.Errorf("couldn't parse provider file name: %s", filename)
+	}
+
+	return Provider{
+		Name:     tokens[0],
+		Version:  tokens[1],
+		OS:       tokens[2],
+		Arch:     tokens[3],
+		Filename: f,
+	}, nil
+}
+
+type SigningKeys struct {
+	GPGPublicKeys []GPGPublicKey `json:"gpg_public_keys,omitempty"`
+}
+
+type GPGPublicKey struct {
+	KeyID      string `json:"key_id,omitempty"`
+	ASCIIArmor string `json:"ascii_armor,omitempty"`
+	Source     string `json:"source,omitempty"`
+	SourceURL  string `json:"source_url,omitempty"`
+}
+
+// The ProviderVersion is a copy from provider.ProviderVersion
+type ProviderVersion struct {
+	Namespace string     `json:"namespace,omitempty"`
+	Name      string     `json:"name,omitempty"`
+	Version   string     `json:"version,omitempty"`
+	Platforms []Platform `json:"platforms,omitempty"`
+}
+
+// Platform is a copy from provider.Platform
+type Platform struct {
+	OS   string `json:"os,omitempty"`
+	Arch string `json:"arch,omitempty"`
+}

--- a/pkg/core/provider_test.go
+++ b/pkg/core/provider_test.go
@@ -1,0 +1,178 @@
+package core
+
+import (
+	assertion "github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestProvider_ArchiveFileName(t *testing.T) {
+	t.Parallel()
+	assert := assertion.New(t)
+
+	testCases := []struct {
+		name             string
+		provider         Provider
+		expectedFileName string
+		expectError      bool
+	}{
+		{
+			name: "valid provider",
+			provider: Provider{
+				Name:    "random",
+				Version: "2.0.0",
+				OS:      "linux",
+				Arch:    "amd64",
+			},
+			expectedFileName: "terraform-provider-random_2.0.0_linux_amd64.zip",
+			expectError:      false,
+		},
+		{
+			name: "missing name",
+			provider: Provider{
+				Version: "2.0.0",
+				OS:      "linux",
+				Arch:    "amd64",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fileName, err := tc.provider.ArchiveFileName()
+			if tc.expectError {
+				assert.Error(err)
+			} else {
+				assert.Equal(tc.expectedFileName, fileName)
+			}
+		})
+	}
+}
+
+func TestProvider_ShasumFileName(t *testing.T) {
+	t.Parallel()
+	assert := assertion.New(t)
+
+	testCases := []struct {
+		name             string
+		provider         Provider
+		expectedFileName string
+		expectError      bool
+	}{
+		{
+			name: "valid provider",
+			provider: Provider{
+				Name:    "random",
+				Version: "2.0.0",
+			},
+			expectedFileName: "terraform-provider-random_2.0.0_SHA256SUMS",
+			expectError:      false,
+		},
+		{
+			name: "missing name",
+			provider: Provider{
+				Version: "2.0.0",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fileName, err := tc.provider.ShasumFileName()
+			if tc.expectError {
+				assert.Error(err)
+			} else {
+				assert.Equal(tc.expectedFileName, fileName)
+			}
+		})
+	}
+}
+
+func TestProvider_ShasumSignatureFileName(t *testing.T) {
+	t.Parallel()
+	assert := assertion.New(t)
+
+	testCases := []struct {
+		name             string
+		provider         Provider
+		expectedFileName string
+		expectError      bool
+	}{
+		{
+			name: "valid provider",
+			provider: Provider{
+				Name:    "random",
+				Version: "2.0.0",
+			},
+			expectedFileName: "terraform-provider-random_2.0.0_SHA256SUMS.sig",
+			expectError:      false,
+		},
+		{
+			name: "missing version",
+			provider: Provider{
+				Name: "random",
+			},
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			fileName, err := tc.provider.ShasumSignatureFileName()
+			if tc.expectError {
+				assert.Error(err)
+			} else {
+				assert.Equal(tc.expectedFileName, fileName)
+			}
+		})
+	}
+}
+
+func TestNewProviderFromArchive(t *testing.T) {
+	t.Parallel()
+	assert := assertion.New(t)
+
+	testCases := []struct {
+		name             string
+		fileName         string
+		expectedProvider Provider
+		expectError      bool
+	}{
+		{
+			name:     "valid filename",
+			fileName: "terraform-provider-random_2.0.0_linux_amd64.zip",
+			expectedProvider: Provider{
+				Name:     "random",
+				Version:  "2.0.0",
+				OS:       "linux",
+				Arch:     "amd64",
+				Filename: "terraform-provider-random_2.0.0_linux_amd64.zip",
+			},
+			expectError: false,
+		},
+		{
+			name:        "invalid filename",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			provider, err := NewProviderFromArchive(tc.fileName)
+			if tc.expectError {
+				assert.Error(err)
+			} else {
+				assert.Equal(tc.fileName, provider.Filename)
+				assert.Equal(tc.expectedProvider.Name, provider.Name)
+				assert.Equal(tc.expectedProvider.Version, provider.Version)
+				assert.Equal(tc.expectedProvider.OS, provider.OS)
+				assert.Equal(tc.expectedProvider.Arch, provider.Arch)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This PR include infrastructure code necessary to start refactoring the existing code and prepare for #22
It contains the `Provider` struct, its associated data types and their methods.