### PR TITLE
Add note about location of Docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,9 +270,17 @@ changelog:
 For general information on how to build and publish providers for Terraform see the official docs:
 https://www.terraform.io/docs/registry/providers.
 
-# Docker
+# Installation
+
+## Docker Image
 
 Images are published to ghcr.io/tiermobility/boring-registry for every tagged release of the project; there is no official image available on Docker Hub.
+
+## Local
+
+Run `make` to build the project and install the `boring-registry` executable into `$GOPATH/bin`. Then
+start the server with `$GOPATH/bin/boring-registry`, or if `$GOPATH/bin` is already on your `$PATH`,
+you can simply run `boring-registry`.
 
 # Roadmap
 

--- a/README.md
+++ b/README.md
@@ -270,6 +270,10 @@ changelog:
 For general information on how to build and publish providers for Terraform see the official docs:
 https://www.terraform.io/docs/registry/providers.
 
+# Docker
+
+Images are published to ghcr.io/tiermobility/boring-registry for every tagged release of the project; there is no official image available on Docker Hub.
+
 # Roadmap
 
 The project is in its very early stages and there is a lot of things we want to tackle. This may mean some breaking changes in the future, but once the project is stable enough we will put quite heavy focus on keeping changes backwards compatible. This project started out as a single server (just serving the Module Registry Protocol), but is now becoming a single binary that can host the server and allow operators to manage the registry using a streamlined interface.


### PR DESCRIPTION
This may help save some time for people wondering about an official Docker image (such as in https://github.com/TierMobility/boring-registry/issues/27).