### PR TITLE
Add migration subcommand for modules

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"github.com/spf13/cobra"
+)
+
+var (
+	//flagMigrateRecursive bool
+	flagDryRun bool
+	//flagTargetBucket string
+)
+
+func init() {
+	rootCmd.AddCommand(migrateCmd)
+	//rootCmd.Flags().BoolVar(&flagMigrateRecursive, "recursive", true, "Recursively traverse <dir> and migrate all modules in subdirectories")
+	migrateCmd.Flags().BoolVar(&flagDryRun, "dry-run", false, "Enable dry-run for the migration")
+	//rootCmd.Flags().StringVar(&flagTargetBucket, "target-bucket", "", "Optionally migrate modules to another bucket")
+}
+
+var migrateCmd = &cobra.Command{
+	Use:   "migrate [flags] MODULE",
+	Short: "Migrate modules",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		ctx := context.Background()
+		storageBackend, err := setupStorage(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to setup storage: %w", err)
+		}
+
+		return storageBackend.MigrateModules(ctx, logger, flagDryRun)
+	},
+}

--- a/pkg/module/storage.go
+++ b/pkg/module/storage.go
@@ -2,8 +2,11 @@ package module
 
 import (
 	"context"
-	"github.com/TierMobility/boring-registry/pkg/core"
 	"io"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+
+	"github.com/go-kit/kit/log"
 )
 
 // Storage represents the repository of Terraform modules.
@@ -11,4 +14,7 @@ type Storage interface {
 	GetModule(ctx context.Context, namespace, name, provider, version string) (core.Module, error)
 	ListModuleVersions(ctx context.Context, namespace, name, provider string) ([]core.Module, error)
 	UploadModule(ctx context.Context, namespace, name, provider, version string, body io.Reader) (core.Module, error)
+
+	// MigrateModules is needed for the migration from 0.7.0 to 0.8.0
+	MigrateModules(ctx context.Context, logger log.Logger, dryRun bool) error
 }

--- a/pkg/module/storage_inmem.go
+++ b/pkg/module/storage_inmem.go
@@ -3,11 +3,14 @@ package module
 import (
 	"context"
 	"fmt"
-	"github.com/TierMobility/boring-registry/pkg/core"
-	"github.com/pkg/errors"
 	"io"
 	"path"
 	"sync"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+
+	"github.com/go-kit/kit/log"
+	"github.com/pkg/errors"
 )
 
 // InmemStorage is a Storage implementation
@@ -96,6 +99,11 @@ func (s *InmemStorage) UploadModule(ctx context.Context, namespace, name, provid
 	s.mu.Unlock()
 
 	return s.GetModule(ctx, namespace, name, provider, version)
+}
+
+func (s *InmemStorage) MigrateModules(ctx context.Context, logger log.Logger, dryRun bool) error {
+	//TODO implement me
+	panic("implement me")
 }
 
 // InmemStorageOption provides additional options for the InmemStorage.

--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -10,9 +10,11 @@ import (
 	"path"
 	"time"
 
+	"github.com/TierMobility/boring-registry/pkg/core"
+
 	credentials "cloud.google.com/go/iam/credentials/apiv1"
 	"cloud.google.com/go/storage"
-	"github.com/TierMobility/boring-registry/pkg/core"
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
@@ -22,17 +24,17 @@ import (
 // GCSStorage is a Storage implementation backed by GCS.
 // GCSStorage implements module.Storage and provider.Storage
 type GCSStorage struct {
-	sc              *storage.Client
-	bucket          string
-	bucketPrefix    string
-	useSignedURL    bool
-	signedURLExpiry time.Duration
-	serviceAccount  string
-	archiveFormat   string
+	sc                  *storage.Client
+	bucket              string
+	bucketPrefix        string
+	useSignedURL        bool
+	signedURLExpiry     time.Duration
+	serviceAccount      string
+	moduleArchiveFormat string
 }
 
 func (s *GCSStorage) GetModule(ctx context.Context, namespace, name, provider, version string) (core.Module, error) {
-	o := s.sc.Bucket(s.bucket).Object(modulePath(s.bucketPrefix, namespace, name, provider, version, s.archiveFormat))
+	o := s.sc.Bucket(s.bucket).Object(modulePath(s.bucketPrefix, namespace, name, provider, version, s.moduleArchiveFormat))
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
 		return core.Module{}, errors.Wrap(ErrModuleNotFound, err.Error())
@@ -70,7 +72,7 @@ func (s *GCSStorage) ListModuleVersions(ctx context.Context, namespace, name, pr
 		if err != nil {
 			return modules, err
 		}
-		m, err := moduleFromObject(attrs.Name, s.archiveFormat)
+		m, err := moduleFromObject(attrs.Name, s.moduleArchiveFormat)
 		if err != nil {
 			// TODO: we're skipping possible failures silently
 			continue
@@ -111,6 +113,42 @@ func (s *GCSStorage) UploadModule(ctx context.Context, namespace, name, provider
 	}
 
 	return s.GetModule(ctx, namespace, name, provider, version)
+}
+
+func (s *GCSStorage) MigrateModules(ctx context.Context, logger log.Logger, dryRun bool) error {
+	q := &storage.Query{
+		Prefix: modulePathPrefix(s.bucketPrefix, "", "", ""),
+	}
+	it := s.sc.Bucket(s.bucket).Objects(ctx, q)
+	for {
+		attrs, err := it.Next()
+		if errors.Is(err, iterator.Done) {
+			break
+		} else if err != nil {
+			return err
+		}
+
+		// Skip already migrated modules
+		if !isUnmigratedModule(s.bucketPrefix, attrs.Name) {
+			continue
+		}
+
+		targetKey := migrationTargetPath(s.bucketPrefix, s.moduleArchiveFormat, attrs.Name)
+		if dryRun {
+			_ = logger.Log("message", "skipping due to dry-run", "source", attrs.Name, "target", targetKey)
+		} else {
+			src := s.sc.Bucket(s.bucket).Object(attrs.Name)
+			dst := s.sc.Bucket(s.bucket).Object(targetKey).If(storage.Conditions{DoesNotExist: true})
+
+			if _, err = dst.CopierFrom(src).Run(ctx); err != nil {
+				return fmt.Errorf("migration failed: %w", err)
+			}
+
+			_ = logger.Log("message", "copied module", "source", attrs.Name, "target", targetKey)
+		}
+	}
+
+	return nil
 }
 
 // GetProvider implements provider.Storage

--- a/pkg/storage/path_test.go
+++ b/pkg/storage/path_test.go
@@ -275,6 +275,18 @@ func TestModuleFromObject(t *testing.T) {
 			expectedError: true,
 		},
 		{
+			annotation:    "module with a hyphen in the name",
+			key:           "/boring-registry/test/modules/hashicorp/private-key/aws/hashicorp-private-key-aws-0.11.0.tar.gz",
+			fileExtension: "tar.gz",
+			expectedError: false,
+			result: core.Module{
+				Namespace: "hashicorp",
+				Name:      "private-key",
+				Provider:  "aws",
+				Version:   "0.11.0",
+			},
+		},
+		{
 			annotation:    "key with pre-release version",
 			key:           "/boring-registry/test/modules/hashicorp/consul/aws/hashicorp-consul-aws-0.11.0-beta1.tar.gz",
 			fileExtension: "tar.gz",

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -142,8 +142,6 @@ func (s *S3Storage) MigrateModules(ctx context.Context, logger log.Logger, dryRu
 		Prefix: aws.String(path.Join(s.bucketPrefix, string(internalModuleType))),
 	}
 
-	waiter := s3.NewObjectExistsWaiter(s.client)
-
 	paginator := s3.NewListObjectsV2Paginator(s.client, input)
 	for paginator.HasMorePages() {
 		resp, err := paginator.NextPage(ctx)
@@ -168,16 +166,6 @@ func (s *S3Storage) MigrateModules(ctx context.Context, logger log.Logger, dryRu
 				})
 				if err != nil {
 					return err
-				}
-
-				err = waiter.Wait(ctx,
-					&s3.HeadObjectInput{
-						Bucket: aws.String(s.bucket),
-						Key:    targetKey,
-					},
-					20*time.Second)
-				if err != nil {
-					return fmt.Errorf("waited for 20s: %w", err)
 				}
 
 				_ = logger.Log("message", "copied module", "source", *obj.Key, "target", targetKey)

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net/url"
 	"path"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/go-kit/kit/log"
 	"github.com/pkg/errors"
 )
 
@@ -131,6 +133,59 @@ func (s *S3Storage) UploadModule(ctx context.Context, namespace, name, provider,
 	}
 
 	return s.GetModule(ctx, namespace, name, provider, version)
+}
+
+// MigrateModules is only a temporary method needed for the migration from 0.7.0 to 0.8.0 and above
+func (s *S3Storage) MigrateModules(ctx context.Context, logger log.Logger, dryRun bool) error {
+	input := &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(path.Join(s.bucketPrefix, string(internalModuleType))),
+	}
+
+	waiter := s3.NewObjectExistsWaiter(s.client)
+
+	paginator := s3.NewListObjectsV2Paginator(s.client, input)
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to page: %w", err)
+		}
+
+		for _, obj := range resp.Contents {
+			if !isUnmigratedModule(s.bucketPrefix, *obj.Key) {
+				_ = logger.Log("message", "skipping...", "key", *obj.Key)
+				continue
+			}
+
+			targetKey := aws.String(migrationTargetPath(s.bucketPrefix, s.moduleArchiveFormat, *obj.Key))
+			if dryRun {
+				_ = logger.Log("message", "skipping due to dry-run", "source", obj.Key, "target", *targetKey)
+			} else {
+				_, err := s.client.CopyObject(ctx, &s3.CopyObjectInput{
+					Bucket:     aws.String(s.bucket),
+					CopySource: aws.String(url.PathEscape(path.Join(s.bucket, *obj.Key))),
+					Key:        targetKey,
+				})
+				if err != nil {
+					return err
+				}
+
+				err = waiter.Wait(ctx,
+					&s3.HeadObjectInput{
+						Bucket: aws.String(s.bucket),
+						Key:    targetKey,
+					},
+					20*time.Second)
+				if err != nil {
+					return fmt.Errorf("waited for 20s: %w", err)
+				}
+
+				_ = logger.Log("message", "copied module", "source", *obj.Key, "target", targetKey)
+			}
+		}
+	}
+
+	return nil
 }
 
 // GetProvider retrieves information about a provider from the S3 storage.


### PR DESCRIPTION
This PR is based on  #38 . Don't merge until that PR is merged and this PR is rebased. 

Adds a `migrate` subcommand that copies existing modules into the correct storage layout for `v0.8.0`.
Check commit 965a126ffe2d8e4e47587774adab3dc129972430 for the changes.