### PR TITLE
feat(migrate): support provider migration

### DIFF
--- a/cmd/migrate.go
+++ b/cmd/migrate.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"fmt"
+
 	"github.com/spf13/cobra"
 )
 
@@ -25,6 +26,10 @@ var migrateCmd = &cobra.Command{
 			return fmt.Errorf("failed to setup storage: %w", err)
 		}
 
-		return storageBackend.MigrateModules(ctx, logger, flagDryRun)
+		if err := storageBackend.MigrateModules(ctx, logger, flagDryRun); err != nil {
+			return err
+		}
+
+		return storageBackend.MigrateProviders(ctx, logger, flagDryRun)
 	},
 }

--- a/pkg/provider/storage.go
+++ b/pkg/provider/storage.go
@@ -2,11 +2,17 @@ package provider
 
 import (
 	"context"
+
 	"github.com/TierMobility/boring-registry/pkg/core"
+
+	"github.com/go-kit/kit/log"
 )
 
 // Storage represents the Storage of Terraform providers.
 type Storage interface {
 	GetProvider(ctx context.Context, namespace, name, version, os, arch string) (core.Provider, error)
 	ListProviderVersions(ctx context.Context, namespace, name string) ([]core.ProviderVersion, error)
+
+	// MigrateProviders is needed for the migration from 0.7.0 to 0.8.0
+	MigrateProviders(ctx context.Context, logger log.Logger, dryRun bool) error
 }

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -176,6 +176,48 @@ func (s *S3Storage) MigrateModules(ctx context.Context, logger log.Logger, dryRu
 	return nil
 }
 
+// MigrateProviders is a temporary method needed for the migration from 0.7.0 to 0.8.0 and above
+func (s *S3Storage) MigrateProviders(ctx context.Context, logger log.Logger, dryRun bool) error {
+	input := &s3.ListObjectsV2Input{
+		Bucket: aws.String(s.bucket),
+		Prefix: aws.String(path.Join(s.bucketPrefix, string(internalProviderType))),
+	}
+
+	paginator := s3.NewListObjectsV2Paginator(s.client, input)
+	for paginator.HasMorePages() {
+		resp, err := paginator.NextPage(ctx)
+		if err != nil {
+			return fmt.Errorf("failed to page: %w", err)
+		}
+
+		for _, obj := range resp.Contents {
+			directory, err := providerMigrationTargetPath(s.bucketPrefix, *obj.Key)
+			if err != nil {
+				return err
+			}
+
+			targetKey := path.Join(directory, path.Base(*obj.Key))
+
+			if dryRun {
+				_ = logger.Log("message", "skipping due to dry-run", "source", obj.Key, "target", targetKey)
+			} else {
+				_, err := s.client.CopyObject(ctx, &s3.CopyObjectInput{
+					Bucket:     aws.String(s.bucket),
+					CopySource: aws.String(url.PathEscape(path.Join(s.bucket, *obj.Key))),
+					Key:        aws.String(targetKey),
+				})
+				if err != nil {
+					return err
+				}
+
+				_ = logger.Log("message", "copied module", "source", *obj.Key, "target", targetKey)
+			}
+		}
+	}
+
+	return nil
+}
+
 // GetProvider retrieves information about a provider from the S3 storage.
 func (s *S3Storage) GetProvider(ctx context.Context, namespace, name, version, os, arch string) (core.Provider, error) {
 	archivePath, shasumPath, shasumSigPath, err := internalProviderPath(s.bucketPrefix, namespace, name, version, os, arch)


### PR DESCRIPTION
* Support migration of providers from `0.7.0` to `0.8.0`
* Provider `zip` archives, `SHA256SUM`,`SHA256SUM.sig` and `signing-keys.json` are copied as-is