### PR TITLE
feat(storage): use only presigned URLs

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -35,14 +35,12 @@ var (
 	flagS3Region          string
 	flagS3Endpoint        string
 	flagS3PathStyle       bool
-	flagS3SignedURL       bool
 	flagS3SignedURLExpiry time.Duration
 
 	// GCS options.
 	flagGCSBucket          string
 	flagGCSPrefix          string
 	flagGCSServiceAccount  string
-	flagGCSSignedURL       bool
 	flagGCSSignedURLExpiry time.Duration
 )
 
@@ -83,16 +81,12 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flagS3Region, "storage-s3-region", "", "S3 bucket region to use for the registry")
 	rootCmd.PersistentFlags().StringVar(&flagS3Endpoint, "storage-s3-endpoint", "", "S3 bucket endpoint URL (required for MINIO)")
 	rootCmd.PersistentFlags().BoolVar(&flagS3PathStyle, "storage-s3-pathstyle", false, "S3 use PathStyle (required for MINIO)")
-	rootCmd.PersistentFlags().BoolVar(&flagS3SignedURL, "storage-s3-signedurl", false, `Generate publicly available signedURLs instead of relying on AWS IAM credentials being set on terraform init.
-WARNING: only use in combination with api-key option.`)
 	rootCmd.PersistentFlags().DurationVar(&flagS3SignedURLExpiry, "storage-s3-signedurl-expiry", 30*time.Second, "Generate S3 signed URL valid for X seconds. Only meaningful if used in combination with `storage-s3-signedurl`")
 	rootCmd.PersistentFlags().StringVar(&flagGCSBucket, "storage-gcs-bucket", "", "Bucket to use when using the GCS registry type")
 	rootCmd.PersistentFlags().StringVar(&flagGCSPrefix, "storage-gcs-prefix", "", "Prefix to use when using the GCS registry type")
 	rootCmd.PersistentFlags().StringVar(&flagGCSServiceAccount, "storage-gcs-sa-email", "", `Google service account email to be used for Application Default Credentials (ADC)
 GOOGLE_APPLICATION_CREDENTIALS environment variable might be used as alternative.
 For GCS presigned URLs this SA needs the iam.serviceAccountTokenCreator role.`)
-	rootCmd.PersistentFlags().BoolVar(&flagGCSSignedURL, "storage-gcs-signedurl", false, `Generate GCS signedURL (public) instead of relying on GCP credentials being set on terraform init.
-WARNING: only use in combination with api-key option.`)
 	rootCmd.PersistentFlags().DurationVar(&flagGCSSignedURLExpiry, "storage-gcs-signedurl-expiry", 30*time.Second, "Generate GCS signed URL valid for X seconds. Only meaningful if used in combination with `gcs-signedurl`")
 }
 

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -210,7 +210,6 @@ func setupStorage(ctx context.Context) (storage.Storage, error) {
 			storage.WithS3StorageBucketEndpoint(flagS3Endpoint),
 			storage.WithS3StoragePathStyle(flagS3PathStyle),
 			storage.WithS3ArchiveFormat(flagModuleArchiveFormat),
-			storage.WithS3StorageUseSignedURL(flagS3SignedURL),
 			storage.WithS3StorageSignedUrlExpiry(flagS3SignedURLExpiry),
 		)
 	case flagGCSBucket != "":
@@ -218,7 +217,6 @@ func setupStorage(ctx context.Context) (storage.Storage, error) {
 			storage.WithGCSStorageBucketPrefix(flagGCSPrefix),
 			storage.WithGCSServiceAccount(flagGCSServiceAccount),
 			storage.WithGCSSignedUrlExpiry(flagGCSSignedURLExpiry),
-			storage.WithGCSUseSignedURL(flagGCSSignedURL),
 		)
 	default:
 		return nil, errors.New("please specify a valid storage provider")


### PR DESCRIPTION
This PR implements #45.
We're not quite consistent on our usage of presigned URLs right now. As providers can only be served with presigned URL, it's currently not sensible to run boring-registry publicly without authentication/authorization anways. Thus we should be safe to use presigned URLs everywhere