### PR TITLE
to suppress usage output on upload errors 

### DIFF
--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -34,8 +34,9 @@ func init() {
 }
 
 var uploadCmd = &cobra.Command{
-	Use:   "upload [flags] MODULE",
-	Short: "Upload modules",
+	Use:          "upload [flags] MODULE",
+	Short:        "Upload modules",
+	SilenceUsage: true,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		storageBackend, err := setupStorage(context.Background())
 		if err != nil {


### PR DESCRIPTION
Fixes #98 
Don't display usage on errors during upload. The error message is enough.