### PR TITLE
fix(serving): use new signing key format on server provider

### DIFF
--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -3,7 +3,6 @@ package storage
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"io"
 	"path"
@@ -215,8 +214,8 @@ func (s *GCSStorage) GetProvider(ctx context.Context, namespace, name, version, 
 		return core.Provider{}, errors.Wrap(err, pathSigningKeys)
 	}
 
-	var signingKey core.GPGPublicKey
-	if err := json.Unmarshal(signingKeysRaw, &signingKey); err != nil {
+	signingKeys, err := unmarshalSigningKeys(signingKeysRaw)
+	if err != nil {
 		return core.Provider{}, err
 	}
 
@@ -241,11 +240,7 @@ func (s *GCSStorage) GetProvider(ctx context.Context, namespace, name, version, 
 		DownloadURL:         zipURL,
 		SHASumsURL:          shasumsURL,
 		SHASumsSignatureURL: signatureURL,
-		SigningKeys: core.SigningKeys{
-			GPGPublicKeys: []core.GPGPublicKey{
-				signingKey,
-			},
-		},
+		SigningKeys:         *signingKeys,
 	}, nil
 }
 


### PR DESCRIPTION
The issue we're addressing on this PR:

Current implementation has a mismatch on the implementation of the signing keys for providers. 

Publishing a provider requires the new format, but serving looks for the old format.