### PR TITLE
feat: support provider network mirror protocol with pull-through cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,12 +11,10 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Dependency directories (remove the comment below to include it)
-# vendor/
-main
-dist/
+# Editors and IDEs
 .idea
 .DS_Store
+.vscode
 
 # Helm related files
 *.tgz

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -81,7 +81,7 @@ func init() {
 	rootCmd.PersistentFlags().StringVar(&flagS3Region, "storage-s3-region", "", "S3 bucket region to use for the registry")
 	rootCmd.PersistentFlags().StringVar(&flagS3Endpoint, "storage-s3-endpoint", "", "S3 bucket endpoint URL (required for MINIO)")
 	rootCmd.PersistentFlags().BoolVar(&flagS3PathStyle, "storage-s3-pathstyle", false, "S3 use PathStyle (required for MINIO)")
-	rootCmd.PersistentFlags().DurationVar(&flagS3SignedURLExpiry, "storage-s3-signedurl-expiry", 30*time.Second, "Generate S3 signed URL valid for X seconds. Only meaningful if used in combination with --storage-s3-signedurl")
+	rootCmd.PersistentFlags().DurationVar(&flagS3SignedURLExpiry, "storage-s3-signedurl-expiry", 5*time.Minute, "Generate S3 signed URL valid for X seconds. Only meaningful if used in combination with --storage-s3-signedurl")
 	rootCmd.PersistentFlags().StringVar(&flagGCSBucket, "storage-gcs-bucket", "", "Bucket to use when using the GCS registry type")
 	rootCmd.PersistentFlags().StringVar(&flagGCSPrefix, "storage-gcs-prefix", "", "Prefix to use when using the GCS registry type")
 	rootCmd.PersistentFlags().StringVar(&flagGCSServiceAccount, "storage-gcs-sa-email", "", `Google service account email to be used for Application Default Credentials (ADC).

--- a/pkg/core/errors.go
+++ b/pkg/core/errors.go
@@ -1,0 +1,43 @@
+package core
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrObjectNotFound = errors.New("failed to locate object")
+)
+
+type ProviderError struct {
+	Reason     string
+	Provider   *Provider
+	StatusCode int
+}
+
+func (p ProviderError) Error() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%s: ", p.Reason))
+	if p.Provider.Hostname != "" {
+		sb.WriteString(fmt.Sprintf("hostname=%s, ", p.Provider.Hostname))
+	}
+	if p.Provider.Namespace != "" {
+		sb.WriteString(fmt.Sprintf("namespace=%s, ", p.Provider.Namespace))
+	}
+	if p.Provider.Name != "" {
+		sb.WriteString(fmt.Sprintf("name=%s, ", p.Provider.Name))
+	}
+	if p.Provider.Version != "" {
+		sb.WriteString(fmt.Sprintf("version=%s, ", p.Provider.Version))
+	}
+	if p.Provider.OS != "" {
+		sb.WriteString(fmt.Sprintf("os=%s, ", p.Provider.OS))
+	}
+	if p.Provider.Arch != "" {
+		sb.WriteString(fmt.Sprintf("arch=%s, ", p.Provider.Arch))
+	}
+	message := sb.String()
+	message = strings.TrimSuffix(message, ", ")
+	return message
+}

--- a/pkg/core/errors_test.go
+++ b/pkg/core/errors_test.go
@@ -1,0 +1,57 @@
+package core
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestProviderError_Error(t *testing.T) {
+	type fields struct {
+		Reason     string
+		Provider   *Provider
+		StatusCode int
+	}
+	tests := []struct {
+		name   string
+		fields fields
+		want   string
+	}{
+		{
+			name: "with hostname, namespace, name",
+			fields: fields{
+				Reason: "this is the prefix",
+				Provider: &Provider{
+					Hostname:  "example.com",
+					Namespace: "example",
+					Name:      "test",
+				},
+			},
+			want: "this is the prefix: hostname=example.com, namespace=example, name=test",
+		},
+		{
+			name: "with hostname, namespace, name, os, and arch",
+			fields: fields{
+				Reason: "this is the prefix",
+				Provider: &Provider{
+					Hostname:  "example.com",
+					Namespace: "example",
+					Name:      "test",
+					Version:   "0.1.2",
+					OS:        "linux",
+					Arch:      "amd64",
+				},
+			},
+			want: "this is the prefix: hostname=example.com, namespace=example, name=test, version=0.1.2, os=linux, arch=amd64",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := ProviderError{
+				Reason:     tt.fields.Reason,
+				Provider:   tt.fields.Provider,
+				StatusCode: tt.fields.StatusCode,
+			}
+			assert.Equalf(t, tt.want, p.Error(), "Error()")
+		})
+	}
+}

--- a/pkg/core/provider.go
+++ b/pkg/core/provider.go
@@ -159,11 +159,16 @@ type GPGPublicKey struct {
 	SourceURL  string `json:"source_url,omitempty"`
 }
 
+type ProviderVersions struct {
+	Versions []ProviderVersion `json:"versions,omitempty"`
+}
+
 // The ProviderVersion is a copy from provider.ProviderVersion
 type ProviderVersion struct {
 	Namespace string     `json:"namespace,omitempty"`
 	Name      string     `json:"name,omitempty"`
 	Version   string     `json:"version,omitempty"`
+	Protocols []string   `json:"protocols,omitempty"`
 	Platforms []Platform `json:"platforms,omitempty"`
 }
 

--- a/pkg/discovery/discovery.go
+++ b/pkg/discovery/discovery.go
@@ -1,5 +1,6 @@
 package discovery
 
+// See https://developer.hashicorp.com/terraform/internals/remote-service-discovery
 type Discovery struct {
 	LoginV1     *LoginV1 `json:"login.v1,omitempty"`
 	ModulesV1   string   `json:"modules.v1,omitempty"`

--- a/pkg/discovery/remote_service_discovery.go
+++ b/pkg/discovery/remote_service_discovery.go
@@ -1,0 +1,150 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strings"
+	"sync"
+)
+
+const (
+	wellKnownEndpoint = ".well-known/terraform.json"
+	contentTypeKey    = "Content-Type"
+	applicationJson   = "application/json"
+	httpsScheme       = "https"
+)
+
+// DiscoveredRemoteService holds the information retrieved during the discovery process
+type DiscoveredRemoteService struct {
+	// URL holds the host name that returned the service discovery payload.
+	// The URLs host can be different from the initial request host due to redirects.
+	// It is the base URL for relative provider paths.
+	URL url.URL
+	wellKnownEndpointResponse
+}
+
+// discoveredRemoteServiceMap wraps sync.Map to prevent mixing up the types
+type discoveredRemoteServiceMap struct {
+	m sync.Map
+}
+
+func (d *discoveredRemoteServiceMap) Load(host string) (*DiscoveredRemoteService, bool) {
+	v, ok := d.m.Load(host)
+	if !ok {
+		return nil, ok
+	}
+
+	discovered, ok := v.(DiscoveredRemoteService)
+	if !ok {
+		panic("failed to type assert to DiscoveredRemoteService")
+	}
+
+	return &discovered, true
+}
+
+func (d *discoveredRemoteServiceMap) Store(host string, ds DiscoveredRemoteService) {
+	d.m.Store(host, ds)
+}
+
+type wellKnownEndpointResponse struct {
+	ModulesV1   string `json:"modules.v1,omitempty"`
+	ProvidersV1 string `json:"providers.v1,omitempty"`
+}
+
+// The RemoteServiceDiscovery struct caches HTTP path prefixes for providers which were discovered over the well-known service discovery mechanism.
+// See: https://developer.hashicorp.com/terraform/internals/remote-service-discovery
+type RemoteServiceDiscovery struct {
+	// We use a sync.Map here as we only write the entry for a given key once but read it many times.
+	// This data structure is optimized for this use case.
+	// The sync.Map is wrapped to enforce storing/retrieving only DiscoveredRemoteService.
+	m      discoveredRemoteServiceMap
+	client *http.Client
+}
+
+// Resolve returns the relative provider path for a given URL
+func (r *RemoteServiceDiscovery) Resolve(ctx context.Context, host string) (*DiscoveredRemoteService, error) {
+	existing, ok := r.m.Load(host)
+	if !ok {
+		discovered, err := r.discover(ctx, host)
+		if err != nil {
+			return nil, err
+		}
+
+		r.m.Store(host, *discovered)
+		return discovered, nil
+	}
+
+	return existing, nil
+}
+
+func (r *RemoteServiceDiscovery) discover(ctx context.Context, host string) (*DiscoveredRemoteService, error) {
+	discovered, err := r.wellKnownEndpoint(ctx, host)
+	if err != nil {
+		return nil, err
+	}
+
+	// The remote service discovery protocol allows for absolute URLs to be returned.
+	// We check whether it's an absolute URL and try to parse it, so that we can return only the path
+	if strings.HasPrefix(discovered.ProvidersV1, "https") {
+		absoluteUrl, err := url.Parse(discovered.ProvidersV1)
+		if err != nil {
+			return nil, fmt.Errorf("failed to parse absolute url: %w", err)
+		}
+		discovered.ProvidersV1 = absoluteUrl.Path
+		discovered.URL.Host = absoluteUrl.Host
+	}
+
+	return discovered, nil
+}
+
+// wellKnownEndpoint returns the response from the discovered upstream registry, as well as the final hostname which served the response.
+// This is relevant in case the HTTP client was redirected to another URL.
+func (r *RemoteServiceDiscovery) wellKnownEndpoint(ctx context.Context, host string) (*DiscoveredRemoteService, error) {
+	u := url.URL{
+		Scheme: httpsScheme,
+		Host:   host,
+		Path:   wellKnownEndpoint,
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, u.String(), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := r.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("failed to retrieve well known endpoint for %s: %w", host, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("failed to resolve well known endpoint for %s: status code is %d", host, resp.StatusCode)
+	}
+
+	if value := resp.Header.Get(contentTypeKey); value != applicationJson {
+		return nil, fmt.Errorf("reponse is of unsupported content-type %s", value)
+	}
+
+	decoder := json.NewDecoder(resp.Body)
+	response := wellKnownEndpointResponse{}
+	if err := decoder.Decode(&response); err != nil {
+		return nil, err
+	}
+
+	return &DiscoveredRemoteService{
+		URL: url.URL{
+			Scheme: httpsScheme,
+			Host:   resp.Request.Host,
+		},
+		wellKnownEndpointResponse: response,
+	}, nil
+}
+
+func NewRemoteServiceDiscovery(client *http.Client) *RemoteServiceDiscovery {
+	return &RemoteServiceDiscovery{
+		client: client,
+	}
+}

--- a/pkg/discovery/remote_service_discovery.go
+++ b/pkg/discovery/remote_service_discovery.go
@@ -87,7 +87,7 @@ func (r *RemoteServiceDiscovery) discover(ctx context.Context, host string) (*Di
 	}
 
 	// The remote service discovery protocol allows for absolute URLs to be returned.
-	// We check whether it's an absolute URL and try to parse it, so that we can return only the path
+	// We check whether it's an absolute URL and try to parse it, so that we can return both the path and the host
 	if strings.HasPrefix(discovered.ProvidersV1, "https") {
 		absoluteUrl, err := url.Parse(discovered.ProvidersV1)
 		if err != nil {

--- a/pkg/discovery/remote_service_discovery_test.go
+++ b/pkg/discovery/remote_service_discovery_test.go
@@ -1,0 +1,135 @@
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+type serverOptions func(response *wellKnownEndpointResponse, host string)
+
+func withAbsoluteProviderURL() serverOptions {
+	return func(r *wellKnownEndpointResponse, host string) {
+		u := url.URL{
+			Scheme: "https",
+			Host:   host,
+			Path:   r.ProvidersV1,
+		}
+		r.ProvidersV1 = u.String()
+	}
+}
+
+func setupServer(statusCode int, response *wellKnownEndpointResponse, opts ...serverOptions) *httptest.Server {
+	// We have to create our own listener, so that we can determine the listening address before starting the server
+	listener, err := net.Listen("tcp", "127.0.0.1:")
+	if err != nil {
+		panic(err)
+	}
+
+	handler := http.HandlerFunc(func(res http.ResponseWriter, req *http.Request) {
+		res.Header().Add(contentTypeKey, "application/json")
+		res.WriteHeader(statusCode)
+
+		for _, option := range opts {
+			option(response, listener.Addr().String())
+		}
+
+		var b []byte
+		if response != nil {
+			var err error
+			b, err = json.Marshal(response)
+			if err != nil {
+				panic(fmt.Errorf("failed to marshal response body: %v", err))
+			}
+		}
+
+		if _, err := res.Write(b); err != nil {
+			panic(err)
+		}
+	})
+	s := httptest.NewUnstartedServer(handler)
+	s.Listener = listener
+	s.StartTLS()
+	return s
+}
+
+func Test_serviceDiscovery_resolve(t *testing.T) {
+	tests := []struct {
+		name    string
+		server  *httptest.Server
+		want    *DiscoveredRemoteService
+		wantErr bool
+	}{
+		{
+			name:   "returning a HTTP 404 status code",
+			server: setupServer(http.StatusNotFound, nil),
+			//response: nil,
+			wantErr: true,
+		},
+		{
+			name: "response with modules",
+			server: setupServer(http.StatusOK, &wellKnownEndpointResponse{
+				ModulesV1: "/v1/modules",
+			}),
+			want: &DiscoveredRemoteService{
+				wellKnownEndpointResponse: wellKnownEndpointResponse{
+					ModulesV1: "/v1/modules",
+				},
+			},
+		},
+		{
+			name: "successfully adding cache entry with relative URL",
+			server: setupServer(http.StatusOK, &wellKnownEndpointResponse{
+				ProvidersV1: "/v1/providers",
+			}),
+			want: &DiscoveredRemoteService{
+				wellKnownEndpointResponse: wellKnownEndpointResponse{
+					ProvidersV1: "/v1/providers",
+				},
+			},
+		},
+		{
+			name: "successfully adding cache entry with absolute URL",
+			server: setupServer(http.StatusOK,
+				&wellKnownEndpointResponse{
+					ProvidersV1: "/v1/providers",
+				},
+				withAbsoluteProviderURL(),
+			),
+			want: &DiscoveredRemoteService{
+				wellKnownEndpointResponse: wellKnownEndpointResponse{
+					ProvidersV1: "/v1/providers",
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := NewRemoteServiceDiscovery(tt.server.Client())
+			u, err := url.Parse(tt.server.URL)
+			if err != nil {
+				t.Fatal(err)
+			}
+			got, err := s.Resolve(context.Background(), u.Host)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("Resolve() error = %v, wantErr %v", err, tt.wantErr)
+			}
+
+			if tt.want != nil {
+				tt.want.URL = url.URL{
+					Scheme: "https",
+					Host:   strings.TrimPrefix(tt.server.URL, "https://"),
+				}
+			}
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/pkg/discovery/remote_service_discovery_test.go
+++ b/pkg/discovery/remote_service_discovery_test.go
@@ -14,10 +14,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-type serverOptions func(response *wellKnownEndpointResponse, host string)
+type serverOptions func(response *WellKnownEndpointResponse, host string)
 
 func withAbsoluteProviderURL() serverOptions {
-	return func(r *wellKnownEndpointResponse, host string) {
+	return func(r *WellKnownEndpointResponse, host string) {
 		u := url.URL{
 			Scheme: "https",
 			Host:   host,
@@ -27,7 +27,7 @@ func withAbsoluteProviderURL() serverOptions {
 	}
 }
 
-func setupServer(statusCode int, response *wellKnownEndpointResponse, opts ...serverOptions) *httptest.Server {
+func setupServer(statusCode int, response *WellKnownEndpointResponse, opts ...serverOptions) *httptest.Server {
 	// We have to create our own listener, so that we can determine the listening address before starting the server
 	listener, err := net.Listen("tcp", "127.0.0.1:")
 	if err != nil {
@@ -76,22 +76,22 @@ func Test_serviceDiscovery_resolve(t *testing.T) {
 		},
 		{
 			name: "response with modules",
-			server: setupServer(http.StatusOK, &wellKnownEndpointResponse{
+			server: setupServer(http.StatusOK, &WellKnownEndpointResponse{
 				ModulesV1: "/v1/modules",
 			}),
 			want: &DiscoveredRemoteService{
-				wellKnownEndpointResponse: wellKnownEndpointResponse{
+				WellKnownEndpointResponse: WellKnownEndpointResponse{
 					ModulesV1: "/v1/modules",
 				},
 			},
 		},
 		{
 			name: "successfully adding cache entry with relative URL",
-			server: setupServer(http.StatusOK, &wellKnownEndpointResponse{
+			server: setupServer(http.StatusOK, &WellKnownEndpointResponse{
 				ProvidersV1: "/v1/providers",
 			}),
 			want: &DiscoveredRemoteService{
-				wellKnownEndpointResponse: wellKnownEndpointResponse{
+				WellKnownEndpointResponse: WellKnownEndpointResponse{
 					ProvidersV1: "/v1/providers",
 				},
 			},
@@ -99,13 +99,13 @@ func Test_serviceDiscovery_resolve(t *testing.T) {
 		{
 			name: "successfully adding cache entry with absolute URL",
 			server: setupServer(http.StatusOK,
-				&wellKnownEndpointResponse{
+				&WellKnownEndpointResponse{
 					ProvidersV1: "/v1/providers",
 				},
 				withAbsoluteProviderURL(),
 			),
 			want: &DiscoveredRemoteService{
-				wellKnownEndpointResponse: wellKnownEndpointResponse{
+				WellKnownEndpointResponse: WellKnownEndpointResponse{
 					ProvidersV1: "/v1/providers",
 				},
 			},

--- a/pkg/mirror/copier.go
+++ b/pkg/mirror/copier.go
@@ -1,0 +1,193 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+
+	"github.com/go-kit/log"
+)
+
+type Copier interface {
+	// copy copies the artifacts of a provider to the pull-through cache/mirror
+	copy(provider *core.Provider)
+}
+
+// mirror implements Copier and ensures that requested providers are replicated to the internal storage asynchronously
+type mirror struct {
+	// done is used to signal termination to potentially multiple goroutines at once
+	done chan struct{}
+
+	storage Storage
+	client  *http.Client
+	logger  log.Logger
+}
+
+// copy should be started in a separate goroutine
+func (m *mirror) copy(provider *core.Provider) {
+	begin := time.Now()
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+
+	// A goroutine that terminates all pending downloads in case the application is shutting down
+	go func() {
+		select {
+		case <-m.done:
+			cancel()
+		case <-ctx.Done():
+			// No-op as the copy process either succeeded and the deferred cancel() function was called
+			// or the operation timed out. In both cases, we just want to terminate the goroutine
+		}
+	}()
+
+	// We download the files from upstream and mirror them to our storage
+	if err := m.signingKeys(ctx, provider); err != nil {
+		_ = m.logger.Log(logKeyValues(provider, err))
+		return
+	}
+
+	if err := m.sha256Sums(ctx, provider); err != nil {
+		_ = m.logger.Log(logKeyValues(provider, err))
+		return
+	}
+
+	if err := m.sha256SumsSignature(ctx, provider); err != nil {
+		_ = m.logger.Log(logKeyValues(provider, err))
+		return
+	}
+
+	// Request the provider archive
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, provider.DownloadURL, nil)
+	if err != nil {
+		_ = m.logger.Log(logKeyValues(provider, err))
+		return
+	}
+	resp, err := m.client.Do(req)
+	if err != nil {
+		_ = m.logger.Log(logKeyValues(provider, err))
+		return
+	}
+	defer resp.Body.Close()
+
+	fileName := provider.ArchiveFileName()
+	if err = m.storage.UploadMirroredFile(ctx, provider, fileName, resp.Body); err != nil {
+		_ = m.logger.Log(logKeyValues(provider, err))
+	}
+	_ = m.logger.Log(
+		"op", "CopyProvider",
+		"hostname", provider.Hostname,
+		"namespace", provider.Namespace,
+		"name", provider.Name,
+		"version", provider.Version,
+		"os", provider.OS,
+		"arch", provider.Arch,
+		"took", time.Since(begin),
+	)
+}
+
+// check if the signing keys exist, if not add it
+func (m *mirror) signingKeys(ctx context.Context, provider *core.Provider) error {
+	needsUpdate := true
+	storedKeys, err := m.storage.MirroredSigningKeys(ctx, provider.Hostname, provider.Namespace)
+	if err != nil {
+		if !errors.Is(err, core.ErrObjectNotFound) {
+			return err
+		}
+
+		// If the signing keys don't exist in the mirror, we override them with the upstream signing keys
+		storedKeys = &provider.SigningKeys
+	} else {
+		storedKeys.GPGPublicKeys, needsUpdate = mergeGPGPublicKeys(provider.SigningKeys.GPGPublicKeys, storedKeys.GPGPublicKeys)
+	}
+
+	if !needsUpdate {
+		return nil
+	}
+
+	return m.storage.UploadMirroredSigningKeys(ctx, provider.Hostname, provider.Namespace, storedKeys)
+}
+
+func (m *mirror) sha256SumsSignature(ctx context.Context, provider *core.Provider) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, provider.SHASumsSignatureURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download SHA256SUMS.sig, statuscode is %v", resp.StatusCode)
+	}
+
+	fileName := provider.ShasumSignatureFileName()
+	return m.storage.UploadMirroredFile(ctx, provider, fileName, resp.Body)
+}
+
+func (m *mirror) sha256Sums(ctx context.Context, provider *core.Provider) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, provider.SHASumsURL, nil)
+	if err != nil {
+		return err
+	}
+	resp, err := m.client.Do(req)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("failed to download SHA256SUMS, statuscode is %v", resp.StatusCode)
+	}
+
+	fileName := provider.ShasumFileName()
+	return m.storage.UploadMirroredFile(ctx, provider, fileName, resp.Body)
+}
+
+func (m *mirror) shutdown(ctx context.Context) {
+	<-ctx.Done()
+	close(m.done)
+}
+
+func NewMirror(ctx context.Context, logger log.Logger, storage Storage) Copier {
+	m := &mirror{
+		done:   make(chan struct{}),
+		logger: logger,
+		client: &http.Client{
+			// This is also the timeout for reading the response body
+			Timeout: 2 * time.Minute,
+		},
+		storage: storage,
+	}
+	go m.shutdown(ctx)
+	return m
+}
+
+func logKeyValues(provider *core.Provider, err error) []string {
+	return []string{
+		"op", "CopyProvider",
+		"hostname", provider.Hostname,
+		"namespace", provider.Namespace,
+		"name", provider.Name,
+		"version", provider.Version,
+		"os", provider.OS,
+		"arch", provider.Arch,
+		"err", err.Error(),
+	}
+}
+
+func mergeGPGPublicKeys(upstreamKeys, mirroredKeys []core.GPGPublicKey) ([]core.GPGPublicKey, bool) {
+	var merged []core.GPGPublicKey
+	for _, upstreamKey := range upstreamKeys {
+		for _, storedKey := range mirroredKeys {
+			if storedKey.KeyID != upstreamKey.KeyID {
+				merged = append(merged, upstreamKey)
+			}
+		}
+	}
+
+	return merged, len(merged) > len(upstreamKeys)
+}

--- a/pkg/mirror/copier_test.go
+++ b/pkg/mirror/copier_test.go
@@ -21,7 +21,7 @@ var exampleSigningKeys = core.SigningKeys{
 	},
 }
 
-func Test_mirror_signingKeys(t *testing.T) {
+func Test_copier_signingKeys(t *testing.T) {
 	type fields struct {
 		done    chan struct{}
 		storage Storage
@@ -112,7 +112,7 @@ func Test_mirror_signingKeys(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			m := &mirror{
+			m := &copier{
 				done:    tt.fields.done,
 				storage: tt.fields.storage,
 			}
@@ -123,7 +123,7 @@ func Test_mirror_signingKeys(t *testing.T) {
 	}
 }
 
-func Test_mirror_sha256SumsSignature(t *testing.T) {
+func Test_copier_sha256SumsSignature(t *testing.T) {
 	type fields struct {
 		done    chan struct{}
 		storage Storage
@@ -200,7 +200,7 @@ func Test_mirror_sha256SumsSignature(t *testing.T) {
 				}
 			}))
 
-			m := &mirror{
+			m := &copier{
 				done:    tt.fields.done,
 				storage: tt.fields.storage,
 				client:  server.Client(),
@@ -216,7 +216,7 @@ func Test_mirror_sha256SumsSignature(t *testing.T) {
 	}
 }
 
-func Test_mirror_sha256Sums(t *testing.T) {
+func Test_copier_sha256Sums(t *testing.T) {
 	tests := []struct {
 		name       string
 		storage    Storage
@@ -261,12 +261,12 @@ func Test_mirror_sha256Sums(t *testing.T) {
 				}
 			}))
 			tt.provider.SHASumsURL = server.URL
-			m := &mirror{
+			m := &copier{
 				storage: tt.storage,
 				client:  server.Client(),
 			}
 			if err := m.sha256Sums(context.Background(), tt.provider); (err != nil) != tt.wantErr {
-				t.Errorf("mirror.sha256Sums() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("sha256Sums() error = %v, wantErr %v", err, tt.wantErr)
 			}
 		})
 	}

--- a/pkg/mirror/copier_test.go
+++ b/pkg/mirror/copier_test.go
@@ -1,0 +1,273 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+)
+
+var exampleSigningKeys = core.SigningKeys{
+	GPGPublicKeys: []core.GPGPublicKey{
+		{
+			KeyID: "123456789",
+			ASCIIArmor: `-----BEGIN PGP PUBLIC KEY BLOCK-----
+-----END PGP PUBLIC KEY BLOCK-----`,
+		},
+	},
+}
+
+func Test_mirror_signingKeys(t *testing.T) {
+	type fields struct {
+		done    chan struct{}
+		storage Storage
+	}
+	tests := []struct {
+		name     string
+		fields   fields
+		provider *core.Provider
+		wantErr  bool
+	}{
+		{
+			name: "failed to access storage",
+			fields: fields{
+				storage: &mockedStorage{
+					mirroredSigningKeys: func(ctx context.Context, hostname, namespace string) (*core.SigningKeys, error) {
+						return nil, errors.New("this is not an ErrObjectNotFound")
+					},
+				},
+			},
+			provider: &core.Provider{
+				Hostname:  "terraform.example.com",
+				Namespace: "example",
+			},
+			wantErr: true,
+		},
+		{
+			name: "existing signing keys not found",
+			fields: fields{
+				storage: &mockedStorage{
+					mirroredSigningKeys: func(ctx context.Context, hostname, namespace string) (*core.SigningKeys, error) {
+						return nil, core.ErrObjectNotFound
+					},
+					uploadMirroredSigningKeys: func(ctx context.Context, hostname, namespace string, signingKeys *core.SigningKeys) error {
+						return nil
+					},
+				},
+			},
+			provider: &core.Provider{
+				Hostname:    "terraform.example.com",
+				Namespace:   "example",
+				SigningKeys: exampleSigningKeys,
+			},
+		},
+		{
+			name: "existing keys needs updating",
+			fields: fields{
+				storage: &mockedStorage{
+					mirroredSigningKeys: func(ctx context.Context, hostname, namespace string) (*core.SigningKeys, error) {
+						return &exampleSigningKeys, nil
+					},
+					uploadMirroredSigningKeys: func(ctx context.Context, hostname, namespace string, signingKeys *core.SigningKeys) error {
+						return nil
+					},
+				},
+			},
+			provider: &core.Provider{
+				Hostname:  "terraform.example.com",
+				Namespace: "example",
+				SigningKeys: core.SigningKeys{
+					GPGPublicKeys: []core.GPGPublicKey{
+						{
+							KeyID: "0987654321",
+							ASCIIArmor: `-----BEGIN PGP PUBLIC KEY BLOCK-----
+-----END PGP PUBLIC KEY BLOCK-----`,
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "signing keys exist already",
+			fields: fields{
+				storage: &mockedStorage{
+					mirroredSigningKeys: func(ctx context.Context, hostname, namespace string) (*core.SigningKeys, error) {
+						return &exampleSigningKeys, nil
+					},
+					uploadMirroredSigningKeys: func(ctx context.Context, hostname, namespace string, signingKeys *core.SigningKeys) error {
+						return nil
+					},
+				},
+			},
+			provider: &core.Provider{
+				Hostname:    "terraform.example.com",
+				Namespace:   "example",
+				SigningKeys: exampleSigningKeys,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := &mirror{
+				done:    tt.fields.done,
+				storage: tt.fields.storage,
+			}
+			if err := m.signingKeys(context.Background(), tt.provider); (err != nil) != tt.wantErr {
+				t.Errorf("signingKeys() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_mirror_sha256SumsSignature(t *testing.T) {
+	type fields struct {
+		done    chan struct{}
+		storage Storage
+	}
+	tests := []struct {
+		name       string
+		statusCode int
+		fields     fields
+		provider   *core.Provider
+		wantErr    bool
+	}{
+		{
+			name:       "connection error",
+			statusCode: http.StatusNotFound,
+			fields: fields{
+				storage: &mockedStorage{
+					uploadMirroredFile: func(ctx context.Context, provider *core.Provider, filename string, reader io.Reader) error {
+						return nil
+					},
+				},
+			},
+			provider: &core.Provider{
+				Hostname:            "terraform.example.com",
+				Namespace:           "example",
+				Name:                "dummy",
+				Version:             "1.2.3",
+				SHASumsSignatureURL: "http://terraform.example.com",
+			},
+			wantErr: true,
+		},
+		{
+			name:       "invalid status code",
+			statusCode: http.StatusNotFound,
+			fields: fields{
+				storage: &mockedStorage{
+					uploadMirroredFile: func(ctx context.Context, provider *core.Provider, filename string, reader io.Reader) error {
+						return nil
+					},
+				},
+			},
+			provider: &core.Provider{
+				Hostname:  "terraform.example.com",
+				Namespace: "example",
+				Name:      "dummy",
+				Version:   "1.2.3",
+			},
+			wantErr: true,
+		},
+		{
+			name:       "success",
+			statusCode: http.StatusOK,
+			fields: fields{
+				storage: &mockedStorage{
+					uploadMirroredFile: func(ctx context.Context, provider *core.Provider, filename string, reader io.Reader) error {
+						return nil
+					},
+				},
+			},
+			provider: &core.Provider{
+				Hostname:  "terraform.example.com",
+				Namespace: "example",
+				Name:      "dummy",
+				Version:   "1.2.3",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.WriteHeader(tt.statusCode)
+				if _, err := writer.Write([]byte("hello-terraform")); err != nil {
+					panic(err)
+				}
+			}))
+
+			m := &mirror{
+				done:    tt.fields.done,
+				storage: tt.fields.storage,
+				client:  server.Client(),
+			}
+			if tt.provider.SHASumsSignatureURL == "" {
+				tt.provider.SHASumsSignatureURL = server.URL
+			}
+
+			if err := m.sha256SumsSignature(context.Background(), tt.provider); (err != nil) != tt.wantErr {
+				t.Errorf("sha256SumsSignature() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func Test_mirror_sha256Sums(t *testing.T) {
+	tests := []struct {
+		name       string
+		storage    Storage
+		statusCode int
+		provider   *core.Provider
+		wantErr    bool
+	}{
+		{
+			name:       "invalid status code",
+			statusCode: http.StatusInternalServerError,
+			provider: &core.Provider{
+				Hostname:  "terraform.example.com",
+				Namespace: "example",
+				Name:      "dummy",
+				Version:   "1.2.3",
+			},
+			wantErr: true,
+		},
+		{
+			name:       "successfully mirror SHA256SUM",
+			statusCode: http.StatusOK,
+			storage: &mockedStorage{
+				uploadMirroredFile: func(ctx context.Context, provider *core.Provider, filename string, reader io.Reader) error {
+					return nil
+				},
+			},
+			provider: &core.Provider{
+				Hostname:  "terraform.example.com",
+				Namespace: "example",
+				Name:      "dummy",
+				Version:   "1.2.3",
+			},
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.WriteHeader(tt.statusCode)
+				if _, err := writer.Write([]byte("hello-terraform")); err != nil {
+					panic(err)
+				}
+			}))
+			tt.provider.SHASumsURL = server.URL
+			m := &mirror{
+				storage: tt.storage,
+				client:  server.Client(),
+			}
+			if err := m.sha256Sums(context.Background(), tt.provider); (err != nil) != tt.wantErr {
+				t.Errorf("mirror.sha256Sums() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}

--- a/pkg/mirror/endpoint.go
+++ b/pkg/mirror/endpoint.go
@@ -1,0 +1,137 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+
+	"github.com/go-kit/kit/endpoint"
+)
+
+type listVersionsRequest struct {
+	Hostname  string `json:"hostname,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
+}
+
+type listVersionsResponse struct {
+	Versions map[string]EmptyObject `json:"versions"`
+}
+
+//func (l listVersionsResponse) Headers() http.Header {
+//	return map[string][]string{http.CanonicalHeaderKey("content-type"): {"application/json"}}
+//}
+
+func listProviderVersionsEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req, ok := request.(listVersionsRequest)
+		if !ok {
+			return nil, fmt.Errorf("type assertion failed for listVersionsRequest")
+		}
+
+		provider := &core.Provider{
+			Hostname:  req.Hostname,
+			Namespace: req.Namespace,
+			Name:      req.Name,
+		}
+
+		if provider.Hostname == "" || provider.Namespace == "" || provider.Name == "" {
+			return nil, ErrVarMissing
+		}
+
+		versions, err := svc.ListProviderVersions(ctx, provider)
+		if err != nil {
+			return nil, err
+		}
+
+		return listVersionsResponse{
+			Versions: versions.Versions,
+		}, nil
+	}
+}
+
+type listProviderInstallationRequest struct {
+	Hostname  string `json:"hostname,omitempty"`
+	Namespace string `json:"namespace,omitempty"`
+	Name      string `json:"name,omitempty"`
+	Version   string `json:"version,omitempty"`
+}
+
+func listProviderInstallationEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req, ok := request.(listProviderInstallationRequest)
+		if !ok {
+			return nil, fmt.Errorf("type assertion failed for listProviderInstallationRequest")
+		}
+
+		provider := &core.Provider{
+			Hostname:  req.Hostname,
+			Namespace: req.Namespace,
+			Name:      req.Name,
+			Version:   req.Version,
+		}
+
+		if provider.Hostname == "" || provider.Namespace == "" || provider.Name == "" || provider.Version == "" {
+			return nil, errors.New("invalid parameters")
+		}
+
+		archives, err := svc.ListProviderInstallation(ctx, provider)
+		if err != nil {
+			return nil, err
+		}
+
+		return archives, nil
+	}
+}
+
+type retrieveProviderArchiveRequest struct {
+	Hostname     string `json:"hostname,omitempty"`
+	Namespace    string `json:"namespace,omitempty"`
+	Name         string `json:"name,omitempty"`
+	Version      string `json:"version,omitempty"`
+	OS           string `json:"os,omitempty"`
+	Architecture string `json:"architecture,omitempty"`
+}
+
+type retrieveProviderArchiveResponse struct {
+	location string
+	mirrorSource
+}
+
+func retrieveProviderArchiveEndpoint(svc Service) endpoint.Endpoint {
+	return func(ctx context.Context, request interface{}) (interface{}, error) {
+		req, ok := request.(retrieveProviderArchiveRequest)
+		if !ok {
+			return nil, fmt.Errorf("type assertion failed for retrieveProviderArchiveRequest")
+		}
+
+		provider := &core.Provider{
+			Hostname:  req.Hostname,
+			Namespace: req.Namespace,
+			Name:      req.Name,
+			Version:   req.Version,
+			OS:        req.OS,
+			Arch:      req.Architecture,
+		}
+
+		if provider.Hostname == "" || provider.Namespace == "" || provider.Name == "" || provider.Version == "" || provider.OS == "" || provider.Arch == "" {
+			return nil, ErrVarMissing
+		}
+
+		return svc.RetrieveProviderArchive(ctx, provider)
+	}
+}
+
+// Copied from provider module
+type downloadResponse struct {
+	OS                  string `json:"os"`
+	Arch                string `json:"arch"`
+	Filename            string `json:"filename"`
+	DownloadURL         string `json:"download_url"`
+	Shasum              string `json:"shasum"`
+	ShasumsURL          string `json:"shasums_url"`
+	ShasumsSignatureURL string `json:"shasums_signature_url"`
+	//SigningKeys         SigningKeys `json:"signing_keys"`
+}

--- a/pkg/mirror/errors.go
+++ b/pkg/mirror/errors.go
@@ -1,0 +1,7 @@
+package mirror
+
+import "errors"
+
+var (
+	ErrVarMissing = errors.New("variable missing")
+)

--- a/pkg/mirror/middleware.go
+++ b/pkg/mirror/middleware.go
@@ -1,0 +1,109 @@
+package mirror
+
+import (
+	"context"
+	"time"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
+)
+
+type mirrorSource struct {
+	isMirror bool
+}
+
+func (m *mirrorSource) fromMirror() bool {
+	return m.isMirror
+}
+
+// Middleware is a Service middleware.
+type Middleware func(Service) Service
+
+type loggingMiddleware struct {
+	next   Service
+	logger log.Logger
+}
+
+func (mw loggingMiddleware) ListProviderVersions(ctx context.Context, provider *core.Provider) (providerVersions *ProviderVersions, err error) {
+	defer func(begin time.Time) {
+		l := []interface{}{
+			"op", "ListProviderVersions",
+			"hostname", provider.Hostname,
+			"namespace", provider.Namespace,
+			"name", provider.Name,
+			"took", time.Since(begin),
+		}
+		logger := level.Info(mw.logger)
+		if err != nil {
+			logger = level.Error(mw.logger)
+			l = append(l, "err", err)
+		} else {
+			l = append(l, "mirror", providerVersions.fromMirror)
+		}
+
+		_ = logger.Log(l...)
+	}(time.Now())
+
+	return mw.next.ListProviderVersions(ctx, provider)
+}
+
+func (mw loggingMiddleware) ListProviderInstallation(ctx context.Context, provider *core.Provider) (archives *Archives, err error) {
+	defer func(begin time.Time) {
+		l := []interface{}{
+			"op", "ListProviderInstallation",
+			"hostname", provider.Hostname,
+			"namespace", provider.Namespace,
+			"name", provider.Name,
+			"took", time.Since(begin),
+		}
+		logger := level.Info(mw.logger)
+		if err != nil {
+			logger = level.Error(mw.logger)
+			l = append(l, "err", err)
+		} else {
+			l = append(l, "mirror", archives.fromMirror)
+		}
+
+		_ = logger.Log(l...)
+	}(time.Now())
+
+	return mw.next.ListProviderInstallation(ctx, provider)
+}
+
+func (mw loggingMiddleware) RetrieveProviderArchive(ctx context.Context, provider *core.Provider) (response *retrieveProviderArchiveResponse, err error) {
+	defer func(begin time.Time) {
+		l := []interface{}{
+			"op", "RetrieveProviderArchive",
+			"hostname", provider.Hostname,
+			"namespace", provider.Namespace,
+			"name", provider.Name,
+			"version", provider.Version,
+			"os", provider.OS,
+			"arch", provider.Arch,
+			"took", time.Since(begin),
+		}
+		logger := level.Info(mw.logger)
+		if err != nil {
+			logger = level.Error(mw.logger)
+			l = append(l, "err", err)
+		} else {
+			l = append(l, "mirror", response.fromMirror())
+		}
+
+		_ = logger.Log(l...)
+	}(time.Now())
+
+	return mw.next.RetrieveProviderArchive(ctx, provider)
+}
+
+// LoggingMiddleware is a logging Service middleware.
+func LoggingMiddleware(logger log.Logger) Middleware {
+	return func(next Service) Service {
+		return &loggingMiddleware{
+			logger: logger,
+			next:   next,
+		}
+	}
+}

--- a/pkg/mirror/middleware.go
+++ b/pkg/mirror/middleware.go
@@ -26,7 +26,7 @@ type loggingMiddleware struct {
 	logger log.Logger
 }
 
-func (mw loggingMiddleware) ListProviderVersions(ctx context.Context, provider *core.Provider) (providerVersions *ProviderVersions, err error) {
+func (mw loggingMiddleware) ListProviderVersions(ctx context.Context, provider *core.Provider) (providerVersions *ListProviderVersionsResponse, err error) {
 	defer func(begin time.Time) {
 		l := []interface{}{
 			"op", "ListProviderVersions",
@@ -40,7 +40,7 @@ func (mw loggingMiddleware) ListProviderVersions(ctx context.Context, provider *
 			logger = level.Error(mw.logger)
 			l = append(l, "err", err)
 		} else {
-			l = append(l, "mirror", providerVersions.fromMirror)
+			l = append(l, "mirror", providerVersions.fromMirror())
 		}
 
 		_ = logger.Log(l...)
@@ -49,7 +49,7 @@ func (mw loggingMiddleware) ListProviderVersions(ctx context.Context, provider *
 	return mw.next.ListProviderVersions(ctx, provider)
 }
 
-func (mw loggingMiddleware) ListProviderInstallation(ctx context.Context, provider *core.Provider) (archives *Archives, err error) {
+func (mw loggingMiddleware) ListProviderInstallation(ctx context.Context, provider *core.Provider) (archives *ListProviderInstallationResponse, err error) {
 	defer func(begin time.Time) {
 		l := []interface{}{
 			"op", "ListProviderInstallation",
@@ -63,7 +63,7 @@ func (mw loggingMiddleware) ListProviderInstallation(ctx context.Context, provid
 			logger = level.Error(mw.logger)
 			l = append(l, "err", err)
 		} else {
-			l = append(l, "mirror", archives.fromMirror)
+			l = append(l, "mirror", archives.fromMirror())
 		}
 
 		_ = logger.Log(l...)

--- a/pkg/mirror/service.go
+++ b/pkg/mirror/service.go
@@ -1,0 +1,206 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+	"github.com/TierMobility/boring-registry/pkg/discovery"
+)
+
+// Service implements the Provider Network Mirror Protocol.
+// For more information see: https://www.terraform.io/docs/internals/provider-network-mirror-protocol.html
+type Service interface {
+	// ListProviderVersions determines which versions are currently available for a particular provider
+	// https://www.terraform.io/docs/internals/provider-network-mirror-protocol.html#list-available-versions
+	ListProviderVersions(ctx context.Context, provider *core.Provider) (*ProviderVersions, error)
+
+	// ListProviderInstallation returns download URLs and associated metadata for the distribution packages for a particular version of a provider
+	// https://www.terraform.io/docs/internals/provider-network-mirror-protocol.html#list-available-installation-packages
+	ListProviderInstallation(ctx context.Context, provider *core.Provider) (*Archives, error)
+
+	// RetrieveProviderArchive returns an io.Reader of a zip archive containing the provider binary for a given provider
+	RetrieveProviderArchive(ctx context.Context, provider *core.Provider) (*retrieveProviderArchiveResponse, error)
+}
+
+type service struct {
+	upstream     upstreamProvider
+	storage      Storage
+	mirrorCopier Copier
+}
+
+func (s *service) ListProviderVersions(ctx context.Context, provider *core.Provider) (*ProviderVersions, error) {
+	upstreamCtx, cancelUpstreamCtx := context.WithTimeout(ctx, 10*time.Second)
+	defer cancelUpstreamCtx()
+	providerVersionsResponse, err := s.upstream.listProviderVersions(upstreamCtx, provider)
+	if err == nil {
+		// The request to the upstream registry was successful, we can transform and return the response
+		return providerVersionsResponse.providerVersions(), nil
+	}
+
+	var urlError *url.Error
+	if isUrlError := errors.As(err, &urlError); !isUrlError {
+		// It's not a network-related error
+		return nil, err
+	}
+
+	// We try to return a response based on the mirror
+	providers, err := s.storage.ListMirroredProviderVersions(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+	response := &ProviderVersions{Versions: map[string]EmptyObject{}, fromMirror: true}
+	for _, p := range providers {
+		response.Versions[p.Version] = EmptyObject{}
+	}
+	return response, nil
+}
+
+func (s *service) ListProviderInstallation(ctx context.Context, provider *core.Provider) (*Archives, error) {
+	upstreamCtx, cancelUpstreamCtx := context.WithTimeout(ctx, 10*time.Second)
+	defer cancelUpstreamCtx()
+	response, err := s.upstream.listProviderVersions(upstreamCtx, provider)
+	if err == nil {
+		// The request to the upstream registry was successful, we can return the response
+		sha256Sums, err := s.upstreamSha256Sums(ctx, provider, response)
+		if err != nil {
+			return nil, err
+		}
+		for _, version := range response.Versions {
+			if version.Version != provider.Version {
+				continue
+			}
+			return transformToArchives(provider, version.Platforms, sha256Sums)
+		}
+	}
+
+	var urlError *url.Error
+	if isUrlError := errors.As(err, &urlError); !isUrlError {
+		// It's not a network-related error
+		return nil, err
+	}
+
+	// We try to return a response based on the mirror
+	providers, err := s.storage.ListMirroredProviderVersions(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+	if len(providers) > 1 {
+		return nil, errors.New("length of returned providers is unexpected")
+	}
+
+	sha256Sums, err := s.mirroredSha256Sums(ctx, provider, providers)
+	if err != nil {
+		return nil, err
+	}
+	archives, err := transformToArchives(provider, providers[0].Platforms, sha256Sums)
+	if err != nil {
+		return nil, err
+	}
+	archives.fromMirror = true
+	return archives, nil
+}
+
+func (s *service) RetrieveProviderArchive(ctx context.Context, provider *core.Provider) (*retrieveProviderArchiveResponse, error) {
+	// If it's in cache, then redirect to storage
+	mirrored, err := s.storage.GetMirroredProvider(ctx, provider)
+	if err == nil {
+		return &retrieveProviderArchiveResponse{
+			location:     mirrored.DownloadURL,
+			mirrorSource: mirrorSource{isMirror: true},
+		}, nil
+	}
+	var providerError *core.ProviderError
+	if !errors.As(err, &providerError) {
+		// It's not a core.ProviderError, and therefore an error that needs to be passed to the caller
+		return nil, err
+	}
+
+	// If not, then redirect to upstream download and start the mirror process
+	upstream, err := s.upstream.getProvider(ctx, provider)
+	if err != nil {
+		return nil, err
+	}
+
+	// Download the provider from upstream and upload to the mirror
+	go s.mirrorCopier.copy(upstream)
+
+	return &retrieveProviderArchiveResponse{
+		location:     upstream.DownloadURL,
+		mirrorSource: mirrorSource{isMirror: false},
+	}, nil
+}
+
+func (s *service) upstreamSha256Sums(ctx context.Context, provider *core.Provider, listResponse *listResponse) (*core.Sha256Sums, error) {
+	if len(listResponse.Versions) == 0 || len(listResponse.Versions[0].Platforms) == 0 {
+		return nil, errors.New("listResponse doesn't contain any platforms")
+	}
+
+	clone := provider.Clone()
+	clone.OS = listResponse.Versions[0].Platforms[0].OS
+	clone.Arch = listResponse.Versions[0].Platforms[0].Arch
+	providerUpstream, err := s.upstream.getProvider(ctx, clone)
+	if err != nil {
+		return nil, err
+	}
+	return s.upstream.shaSums(ctx, providerUpstream)
+}
+
+func (s *service) mirroredSha256Sums(ctx context.Context, provider *core.Provider, providerVersions []core.ProviderVersion) (*core.Sha256Sums, error) {
+	if len(providerVersions) == 0 || len(providerVersions[0].Platforms) == 0 {
+		return nil, errors.New("response doesn't contain any platforms")
+	}
+
+	clone := provider.Clone()
+	clone.OS = providerVersions[0].Platforms[0].OS
+	clone.Arch = providerVersions[0].Platforms[0].Arch
+	mirroredProvider, err := s.storage.GetMirroredProvider(ctx, clone)
+	if err != nil {
+		return nil, err
+	}
+	return s.storage.MirroredSha256Sum(ctx, mirroredProvider)
+}
+
+func NewService(s Storage, c Copier) Service {
+	remoteServiceDiscovery := discovery.NewRemoteServiceDiscovery(http.DefaultClient)
+	svc := &service{
+		upstream:     newUpstreamProviderRegistry(remoteServiceDiscovery),
+		storage:      s,
+		mirrorCopier: c,
+	}
+
+	return svc
+}
+
+func transformToArchives(provider *core.Provider, platforms []core.Platform, sha256Sums *core.Sha256Sums) (*Archives, error) {
+	archives := &Archives{
+		Archives: map[string]Archive{},
+	}
+
+	for _, p := range platforms {
+		provider.OS = p.OS
+		provider.Arch = p.Arch
+
+		checksum, err := sha256Sums.Checksum(provider.ArchiveFileName())
+		if err != nil {
+			return nil, err
+		}
+
+		key := fmt.Sprintf("%s_%s", p.OS, p.Arch)
+		archives.Archives[key] = Archive{
+			Url: provider.ArchiveFileName(),
+			Hashes: []string{
+				// The checksum has to be prefixed with the `zh:` prefix
+				// See the documentation for more context:
+				// https://developer.hashicorp.com/terraform/language/files/dependency-lock#zh
+				fmt.Sprintf("zh:%s", checksum),
+			},
+		}
+	}
+
+	return archives, nil
+}

--- a/pkg/mirror/service.go
+++ b/pkg/mirror/service.go
@@ -138,9 +138,17 @@ func (s *service) upstreamSha256Sums(ctx context.Context, provider *core.Provide
 		return nil, errors.New("core.ProviderVersions doesn't contain any platforms")
 	}
 
+	// To retrieve the SHA256SUM, we need to construct a core.Provider that has all required fields set to download the provider from upstream.
+	// As the SHA256SUM file is the same for all platforms, we iterate over the versions and choose the first platform from the matching version.
 	clone := provider.Clone()
-	clone.OS = versions.Versions[0].Platforms[0].OS
-	clone.Arch = versions.Versions[0].Platforms[0].Arch
+	for _, v := range versions.Versions {
+		if v.Version == provider.Version {
+			clone.OS = v.Platforms[0].OS
+			clone.Arch = v.Platforms[0].Arch
+			break
+		}
+	}
+
 	providerUpstream, err := s.upstream.getProvider(ctx, clone)
 	if err != nil {
 		return nil, err

--- a/pkg/mirror/service_test.go
+++ b/pkg/mirror/service_test.go
@@ -1,0 +1,487 @@
+package mirror
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"github.com/TierMobility/boring-registry/pkg/core"
+	"io"
+	"net/url"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type mockedUpstreamProvider struct {
+	customListProviderVersions func(ctx context.Context, provider *core.Provider) (*listResponse, error)
+	customGetProvider          func(ctx context.Context, provider *core.Provider) (*core.Provider, error)
+	customShaSums              func(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error)
+}
+
+func (m *mockedUpstreamProvider) listProviderVersions(ctx context.Context, provider *core.Provider) (*listResponse, error) {
+	return m.customListProviderVersions(ctx, provider)
+}
+
+func (m *mockedUpstreamProvider) getProvider(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+	return m.customGetProvider(ctx, provider)
+}
+
+func (m *mockedUpstreamProvider) shaSums(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error) {
+	return m.customShaSums(ctx, provider)
+}
+
+type mockedStorage struct {
+	listMirrorProviderVersions func(ctx context.Context, provider *core.Provider) ([]core.ProviderVersion, error)
+	getMirroredProvider        func(ctx context.Context, provider *core.Provider) (*core.Provider, error)
+	mirroredSha256Sum          func(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error)
+	uploadMirroredFile         func(ctx context.Context, provider *core.Provider, filename string, reader io.Reader) error
+	mirroredSigningKeys        func(ctx context.Context, hostname, namespace string) (*core.SigningKeys, error)
+	uploadMirroredSigningKeys  func(ctx context.Context, hostname, namespace string, signingKeys *core.SigningKeys) error
+}
+
+func (m *mockedStorage) ListMirroredProviderVersions(ctx context.Context, provider *core.Provider) ([]core.ProviderVersion, error) {
+	return m.listMirrorProviderVersions(ctx, provider)
+}
+
+func (m *mockedStorage) GetMirroredProvider(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+	return m.getMirroredProvider(ctx, provider)
+}
+
+func (m *mockedStorage) UploadMirroredFile(ctx context.Context, provider *core.Provider, fileName string, reader io.Reader) error {
+	return m.uploadMirroredFile(ctx, provider, fileName, reader)
+}
+
+func (m *mockedStorage) MirroredSigningKeys(ctx context.Context, hostname, namespace string) (*core.SigningKeys, error) {
+	return m.mirroredSigningKeys(ctx, hostname, namespace)
+}
+
+func (m *mockedStorage) UploadMirroredSigningKeys(ctx context.Context, hostname, namespace string, signingKeys *core.SigningKeys) error {
+	return m.uploadMirroredSigningKeys(ctx, hostname, namespace, signingKeys)
+}
+
+func (m *mockedStorage) MirroredSha256Sum(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error) {
+	return m.mirroredSha256Sum(ctx, provider)
+}
+
+func Test_service_ListProviderVersions(t *testing.T) {
+	type args struct {
+		ctx      context.Context
+		provider *core.Provider
+	}
+	tests := []struct {
+		name    string
+		svc     Service
+		args    args
+		want    *ProviderVersions
+		wantErr bool
+	}{
+		{
+			name: "expired context",
+			svc: &service{
+				upstream: &mockedUpstreamProvider{
+					customListProviderVersions: func(ctx context.Context, provider *core.Provider) (*listResponse, error) {
+						<-ctx.Done()
+						return nil, ctx.Err()
+					},
+				},
+			},
+			args: func() args {
+				// The cancel function has to be ignored, as we cannot easily cancel it
+				ctx, _ := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+				return args{
+					ctx: ctx,
+					provider: &core.Provider{
+						Namespace: "hashicorp",
+						Name:      "random",
+					},
+				}
+			}(),
+			wantErr: true,
+		},
+		{
+			name: "failed to retrieve from upstream and from mirror",
+			svc: &service{
+				upstream: &mockedUpstreamProvider{
+					customListProviderVersions: func(ctx context.Context, provider *core.Provider) (*listResponse, error) {
+						// mock url.Error from client to upstream to simulate unavailable upstream
+						return nil, &url.Error{}
+					},
+				},
+				storage: &mockedStorage{
+					listMirrorProviderVersions: func(ctx context.Context, provider *core.Provider) ([]core.ProviderVersion, error) {
+						// return core.ProviderError to simulate that providers are not in the mirror
+						return nil, &core.ProviderError{
+							Reason: "mocked provider error",
+						}
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "valid upstream response",
+			svc: &service{
+				upstream: &mockedUpstreamProvider{
+					customListProviderVersions: func(ctx context.Context, provider *core.Provider) (*listResponse, error) {
+						return &listResponse{
+							Versions: []listResponseVersion{
+								{
+									Version: "0.1.2",
+									Platforms: []core.Platform{
+										{
+											OS:   "linux",
+											Arch: "amd64",
+										},
+									},
+								},
+							},
+						}, nil
+					},
+				},
+			},
+			want: &ProviderVersions{
+				Versions: map[string]EmptyObject{
+					"0.1.2": {},
+				},
+			},
+		},
+		{
+			name: "upstream unavailable, response from mirror",
+			svc: &service{
+				upstream: &mockedUpstreamProvider{
+					customListProviderVersions: func(ctx context.Context, provider *core.Provider) (*listResponse, error) {
+						// mock url.Error from client to upstream to simulate unavailable upstream
+						return nil, &url.Error{}
+					},
+				},
+				storage: &mockedStorage{
+					listMirrorProviderVersions: func(ctx context.Context, provider *core.Provider) ([]core.ProviderVersion, error) {
+						return []core.ProviderVersion{
+							{
+								Namespace: "hashicorp",
+								Name:      "random",
+								Version:   "0.1.2",
+								Platforms: []core.Platform{
+									{
+										OS:   "linux",
+										Arch: "amd64",
+									},
+									{
+										OS:   "linux",
+										Arch: "arm64",
+									},
+								},
+							},
+							{
+								Namespace: "hashicorp",
+								Name:      "random",
+								Version:   "1.2.3",
+							},
+						}, nil
+					},
+				},
+			},
+			want: &ProviderVersions{
+				Versions: map[string]EmptyObject{
+					"0.1.2": {},
+					"1.2.3": {},
+				},
+				fromMirror: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.args.ctx != nil {
+				ctx = tt.args.ctx
+			}
+
+			got, err := tt.svc.ListProviderVersions(ctx, tt.args.provider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ListProviderVersions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ListProviderVersions() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_service_ListProviderInstallation(t *testing.T) {
+	type args struct {
+		ctx      context.Context
+		provider *core.Provider
+	}
+	tests := []struct {
+		name    string
+		svc     Service
+		args    args
+		want    *Archives
+		wantErr bool
+	}{
+		{
+			name: "failed to retrieve from upstream and from mirror",
+			svc: &service{
+				upstream: &mockedUpstreamProvider{
+					customListProviderVersions: func(ctx context.Context, provider *core.Provider) (*listResponse, error) {
+						return nil, &url.Error{}
+					},
+				},
+				storage: &mockedStorage{
+					listMirrorProviderVersions: func(ctx context.Context, provider *core.Provider) ([]core.ProviderVersion, error) {
+						return nil, errors.New("mocked error")
+					},
+				},
+			},
+			args: args{
+				ctx: context.Background(),
+				provider: &core.Provider{
+					Hostname:  "registry.example.com",
+					Namespace: "hashicorp",
+					Name:      "random",
+					Version:   "0.1.2",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "successfully retrieve response from upstream",
+			svc: &service{
+				upstream: &mockedUpstreamProvider{
+					customListProviderVersions: func(ctx context.Context, provider *core.Provider) (*listResponse, error) {
+						return &listResponse{
+							Versions: []listResponseVersion{
+								{
+									Version: "0.1.0",
+									Platforms: []core.Platform{
+										{
+											OS:   "linux",
+											Arch: "amd64",
+										},
+										{
+											OS:   "linux",
+											Arch: "arm64",
+										},
+									},
+								},
+								{
+									Version: "0.1.2",
+									Platforms: []core.Platform{
+										{
+											OS:   "linux",
+											Arch: "amd64",
+										},
+									},
+								},
+							},
+						}, nil
+					},
+					customGetProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+						return &core.Provider{
+							Hostname:   "registry.example.com",
+							Namespace:  "hashicorp",
+							Name:       "random",
+							Version:    "0.1.0",
+							SHASumsURL: "https://registry.example.com/this/is/the/shasums/file",
+						}, nil
+					},
+					customShaSums: func(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error) {
+						return &core.Sha256Sums{
+							Entries: map[string][]byte{
+								"terraform-provider-random_0.1.0_linux_amd64.zip": []byte("123456789"),
+								"terraform-provider-random_0.1.0_linux_arm64.zip": []byte("987654321"),
+							},
+						}, nil
+					},
+				},
+			},
+			args: args{
+				ctx: context.Background(),
+				provider: &core.Provider{
+					Hostname:  "registry.example.com",
+					Namespace: "hashicorp",
+					Name:      "random",
+					Version:   "0.1.0",
+				},
+			},
+			want: &Archives{
+				Archives: map[string]Archive{
+					"linux_amd64": {
+						Url:    "terraform-provider-random_0.1.0_linux_amd64.zip",
+						Hashes: []string{fmt.Sprintf("zh:%x", []byte("123456789"))},
+					},
+					"linux_arm64": {
+						Url:    "terraform-provider-random_0.1.0_linux_arm64.zip",
+						Hashes: []string{fmt.Sprintf("zh:%x", []byte("987654321"))},
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "upstream fails but mirror succeeds",
+			svc: &service{
+				upstream: &mockedUpstreamProvider{
+					customListProviderVersions: func(ctx context.Context, provider *core.Provider) (*listResponse, error) {
+						return nil, &url.Error{}
+					},
+				},
+				storage: &mockedStorage{
+					listMirrorProviderVersions: func(ctx context.Context, provider *core.Provider) ([]core.ProviderVersion, error) {
+						return []core.ProviderVersion{
+							{
+								Namespace: "hashicorp",
+								Name:      "random",
+								Version:   "1.2.3",
+								Platforms: []core.Platform{
+									{
+										OS:   "linux",
+										Arch: "amd64",
+									},
+									{
+										OS:   "linux",
+										Arch: "arm64",
+									},
+								},
+							},
+						}, nil
+					},
+					getMirroredProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+						return &core.Provider{
+							Hostname:   "registry.example.com",
+							Namespace:  "hashicorp",
+							Name:       "random",
+							Version:    "1.2.3",
+							OS:         "linux",
+							Arch:       "amd64",
+							SHASumsURL: "https://registry.example.com/this/is/the/shasums/file",
+						}, nil
+					},
+					mirroredSha256Sum: func(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error) {
+						return &core.Sha256Sums{
+							Entries: map[string][]byte{
+								"terraform-provider-random_1.2.3_linux_amd64.zip": []byte("123456789"),
+								"terraform-provider-random_1.2.3_linux_arm64.zip": []byte("987654321"),
+							},
+						}, nil
+					},
+				},
+			},
+			args: args{
+				ctx: context.Background(),
+				provider: &core.Provider{
+					Hostname:  "registry.example.com",
+					Namespace: "hashicorp",
+					Name:      "random",
+					Version:   "1.2.3",
+				},
+			},
+			want: &Archives{
+				Archives: map[string]Archive{
+					"linux_amd64": {
+						Url:    "terraform-provider-random_1.2.3_linux_amd64.zip",
+						Hashes: []string{fmt.Sprintf("zh:%x", []byte("123456789"))},
+					},
+					"linux_arm64": {
+						Url:    "terraform-provider-random_1.2.3_linux_arm64.zip",
+						Hashes: []string{fmt.Sprintf("zh:%x", []byte("987654321"))},
+					},
+				},
+				fromMirror: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.args.ctx != nil {
+				ctx = tt.args.ctx
+			}
+
+			got, err := tt.svc.ListProviderInstallation(ctx, tt.args.provider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ListProviderInstallation() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("ListProviderInstallation() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_service_RetrieveProviderArchive(t *testing.T) {
+	type args struct {
+		ctx      context.Context
+		provider *core.Provider
+	}
+	tests := []struct {
+		name    string
+		svc     service
+		args    args
+		want    *retrieveProviderArchiveResponse
+		wantErr bool
+	}{
+		{
+			name: "provider exists in the mirror",
+			svc: service{
+				//upstreamProvider: &mockedUpstreamProvider{},
+				storage: &mockedStorage{
+					getMirroredProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+						provider.DownloadURL = "terraform-provider-random_2.0.0_linux_amd64.zip"
+						return provider, nil
+					},
+				},
+			},
+			args: args{
+				provider: &core.Provider{
+					Hostname: "terraform.example.com",
+					Name:     "random",
+					Version:  "2.0.0",
+					OS:       "linux",
+					Arch:     "amd64",
+				},
+			},
+			want: &retrieveProviderArchiveResponse{
+				location:     "terraform-provider-random_2.0.0_linux_amd64.zip",
+				mirrorSource: mirrorSource{isMirror: true},
+			},
+		},
+		{
+			name: "a non-core.ProviderError happened while looking up the provider in the mirror",
+			svc: service{
+				//upstreamProvider: &mockedUpstreamProvider{},
+				storage: &mockedStorage{
+					getMirroredProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+						return &core.Provider{}, errors.New("mocked error")
+					},
+				},
+			},
+			wantErr: true,
+		},
+		//{
+		//	name: "the provider is not in the mirror",
+		//},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ctx := context.Background()
+			if tt.args.ctx != nil {
+				ctx = tt.args.ctx
+			}
+
+			got, err := tt.svc.RetrieveProviderArchive(ctx, tt.args.provider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RetrieveProviderArchive() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("RetrieveProviderArchive() got = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/mirror/service_test.go
+++ b/pkg/mirror/service_test.go
@@ -87,8 +87,8 @@ func Test_service_ListProviderVersions(t *testing.T) {
 				},
 			},
 			args: func() args {
-				// The cancel function has to be ignored, as we cannot easily cancel it
-				ctx, _ := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+				ctx, cancel := context.WithTimeout(context.Background(), 1*time.Nanosecond)
+				cancel() // cancel the context to pass expired context to function
 				return args{
 					ctx: ctx,
 					provider: &core.Provider{

--- a/pkg/mirror/service_test.go
+++ b/pkg/mirror/service_test.go
@@ -436,7 +436,6 @@ func Test_service_RetrieveProviderArchive(t *testing.T) {
 		{
 			name: "provider exists in the mirror",
 			svc: service{
-				//upstreamProvider: &mockedUpstreamProvider{},
 				storage: &mockedStorage{
 					getMirroredProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
 						provider.DownloadURL = "terraform-provider-random_2.0.0_linux_amd64.zip"
@@ -461,10 +460,25 @@ func Test_service_RetrieveProviderArchive(t *testing.T) {
 		{
 			name: "a non-core.ProviderError happened while looking up the provider in the mirror",
 			svc: service{
-				//upstreamProvider: &mockedUpstreamProvider{},
 				storage: &mockedStorage{
 					getMirroredProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
-						return &core.Provider{}, errors.New("mocked error")
+						return nil, errors.New("mocked error")
+					},
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "error when retrieving the provider from upstram",
+			svc: service{
+				upstream: &mockedUpstreamProvider{
+					customGetProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+						return nil, errors.New("mocked error")
+					},
+				},
+				storage: &mockedStorage{
+					getMirroredProvider: func(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+						return nil, &core.ProviderError{}
 					},
 				},
 			},

--- a/pkg/mirror/storage.go
+++ b/pkg/mirror/storage.go
@@ -25,6 +25,6 @@ type Storage interface {
 	// Existing signing keys are overwritten
 	UploadMirroredSigningKeys(ctx context.Context, hostname, namespace string, signingKeys *core.SigningKeys) error
 
-	// Retrieve the
+	// Retrieve the SHA256SUM from storage
 	MirroredSha256Sum(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error)
 }

--- a/pkg/mirror/storage.go
+++ b/pkg/mirror/storage.go
@@ -10,7 +10,7 @@ import (
 type Storage interface {
 	// ListMirroredProviderVersions returns all matching provider versions for a given hostname, namespace, and name
 	// The provider version can be set to narrow-down the search and return only a single provider
-	ListMirroredProviderVersions(ctx context.Context, provider *core.Provider) (*core.ProviderVersions, error)
+	ListMirroredProviders(ctx context.Context, provider *core.Provider) ([]*core.Provider, error)
 
 	// GetMirroredProvider returns the mirrored provider or a core.ProviderError in case it cannot be located
 	GetMirroredProvider(ctx context.Context, provider *core.Provider) (*core.Provider, error)

--- a/pkg/mirror/storage.go
+++ b/pkg/mirror/storage.go
@@ -1,0 +1,29 @@
+package mirror
+
+import (
+	"context"
+	"io"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+)
+
+type Storage interface {
+	// ListMirroredProviderVersions returns all matching provider versions for a given hostname, namespace, and name
+	// The provider version can be set to narrow-down the search and return only a single provider
+	ListMirroredProviderVersions(ctx context.Context, provider *core.Provider) ([]core.ProviderVersion, error)
+
+	// GetMirroredProvider returns the mirrored provider or a core.ProviderError in case it cannot be located
+	GetMirroredProvider(ctx context.Context, provider *core.Provider) (*core.Provider, error)
+
+	// UploadMirroredFile uploads a file that belongs to a provider release
+	UploadMirroredFile(ctx context.Context, provider *core.Provider, fileName string, reader io.Reader) error
+
+	// MirroredSigningKeys retrieves the signing keys for mirrored providers
+	MirroredSigningKeys(ctx context.Context, hostname, namespace string) (*core.SigningKeys, error)
+
+	// UploadMirroredSigningKeys uploads signing keys for mirrored providers
+	// Existing signing keys are overwritten
+	UploadMirroredSigningKeys(ctx context.Context, hostname, namespace string, signingKeys *core.SigningKeys) error
+
+	MirroredSha256Sum(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error)
+}

--- a/pkg/mirror/storage.go
+++ b/pkg/mirror/storage.go
@@ -10,7 +10,7 @@ import (
 type Storage interface {
 	// ListMirroredProviderVersions returns all matching provider versions for a given hostname, namespace, and name
 	// The provider version can be set to narrow-down the search and return only a single provider
-	ListMirroredProviderVersions(ctx context.Context, provider *core.Provider) ([]core.ProviderVersion, error)
+	ListMirroredProviderVersions(ctx context.Context, provider *core.Provider) (*core.ProviderVersions, error)
 
 	// GetMirroredProvider returns the mirrored provider or a core.ProviderError in case it cannot be located
 	GetMirroredProvider(ctx context.Context, provider *core.Provider) (*core.Provider, error)
@@ -25,5 +25,6 @@ type Storage interface {
 	// Existing signing keys are overwritten
 	UploadMirroredSigningKeys(ctx context.Context, hostname, namespace string, signingKeys *core.SigningKeys) error
 
+	// Retrieve the
 	MirroredSha256Sum(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error)
 }

--- a/pkg/mirror/transport.go
+++ b/pkg/mirror/transport.go
@@ -1,0 +1,347 @@
+package mirror
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/TierMobility/boring-registry/pkg/auth"
+	"github.com/TierMobility/boring-registry/pkg/core"
+	"io"
+	"net/http"
+
+	"github.com/go-kit/kit/endpoint"
+	httptransport "github.com/go-kit/kit/transport/http"
+	"github.com/gorilla/mux"
+	"github.com/pkg/errors"
+)
+
+type muxVar string
+
+const (
+	varHostname     muxVar = "hostname"
+	varNamespace    muxVar = "namespace"
+	varName         muxVar = "name"
+	varVersion      muxVar = "version"
+	varOS           muxVar = "os"
+	varArchitecture muxVar = "architecture"
+)
+
+type header string
+
+// EmptyObject exists to return an `{}` JSON object to match the protocol spec
+type EmptyObject struct{}
+
+// ProviderVersions holds the response that is passed to the endpoint
+type ProviderVersions struct {
+	Versions map[string]EmptyObject `json:"versions"`
+
+	// fromMirror is true if the response was composed of providers from the mirror
+	fromMirror bool
+}
+
+type Archives struct {
+	Archives map[string]Archive `json:"archives"`
+
+	// fromMirror is true if the response was composed of providers from the mirror
+	fromMirror bool
+}
+
+type Archive struct {
+	Url    string   `json:"url"`
+	Hashes []string `json:"hashes,omitempty"`
+}
+
+// MakeHandler returns a fully initialized http.Handler.
+func MakeHandler(svc Service, auth endpoint.Middleware, options ...httptransport.ServerOption) http.Handler {
+	r := mux.NewRouter().StrictSlash(true)
+
+	r.Methods("GET").Path(`/{hostname}/{namespace}/{name}/index.json`).Handler(
+		httptransport.NewServer(
+			auth(listProviderVersionsEndpoint(svc)),
+			decodeListVersionsRequest,
+			EncodeJSONResponse,
+			append(
+				options,
+				httptransport.ServerBefore(extractMuxVars(varHostname, varNamespace, varName)),
+				httptransport.ServerBefore(extractHeaders("Authorization")),
+			)...,
+		),
+	)
+
+	r.Methods("GET").Path(`/{hostname}/{namespace}/{name}/{version}.json`).Handler(
+		httptransport.NewServer(
+			auth(listProviderInstallationEndpoint(svc)),
+			decodeListInstallationRequest,
+			EncodeJSONResponse,
+			append(
+				options,
+				httptransport.ServerBefore(extractMuxVars(varHostname, varNamespace, varName, varVersion)),
+				httptransport.ServerBefore(extractHeaders("Authorization")),
+			)...,
+		),
+	)
+
+	r.Methods("GET").Path(`/{hostname}/{namespace}/{name}/terraform-provider-{nameplaceholder}_{version}_{os}_{architecture}.zip`).Handler(
+		httptransport.NewServer(
+			auth(retrieveProviderArchiveEndpoint(svc)),
+			decodeRetrieveProviderArchiveRequest,
+			//EncodeZipResponse,
+			encodedMirroredResponse,
+			append(
+				options,
+				httptransport.ServerBefore(extractMuxVars(varHostname, varNamespace, varName, varVersion, varOS, varArchitecture)),
+				httptransport.ServerBefore(extractHeaders("Authorization")),
+			)...,
+		),
+	)
+	return r
+}
+
+func pathPortions(ctx context.Context) (string, string, string, error) {
+	hostname, ok := ctx.Value(varHostname).(string)
+	if !ok {
+		return "", "", "", fmt.Errorf("hostname path portion missing")
+	}
+
+	namespace, ok := ctx.Value(varNamespace).(string)
+	if !ok {
+		return "", "", "", fmt.Errorf("namespace path portion missing")
+	}
+
+	name, ok := ctx.Value(varName).(string)
+	if !ok {
+		return "", "", "", fmt.Errorf("name path portion missing")
+	}
+
+	return hostname, namespace, name, nil
+}
+
+func decodeListVersionsRequest(ctx context.Context, _ *http.Request) (interface{}, error) {
+	hostname, namespace, name, err := pathPortions(ctx)
+	return listVersionsRequest{
+		Hostname:  hostname,
+		Namespace: namespace,
+		Name:      name,
+	}, err
+}
+
+func decodeListInstallationRequest(ctx context.Context, _ *http.Request) (interface{}, error) {
+	hostname, namespace, name, err := pathPortions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	version, ok := ctx.Value(varVersion).(string)
+	if !ok {
+		return nil, fmt.Errorf("version path portion missing")
+	}
+
+	return listProviderInstallationRequest{
+		Hostname:  hostname,
+		Namespace: namespace,
+		Name:      name,
+		Version:   version,
+	}, nil
+}
+
+func decodeRetrieveProviderArchiveRequest(ctx context.Context, _ *http.Request) (interface{}, error) {
+	hostname, namespace, name, err := pathPortions(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	version, ok := ctx.Value(varVersion).(string)
+	if !ok {
+		return nil, fmt.Errorf("%s path portion missing", string(varVersion))
+	}
+
+	os, ok := ctx.Value(varOS).(string)
+	if !ok {
+		return nil, fmt.Errorf("%s path portion missing", string(varOS))
+	}
+
+	architecture, ok := ctx.Value(varArchitecture).(string)
+	if !ok {
+		return nil, fmt.Errorf("%s path portion missing", string(varArchitecture))
+	}
+
+	return retrieveProviderArchiveRequest{
+		Hostname:     hostname,
+		Namespace:    namespace,
+		Name:         name,
+		Version:      version,
+		OS:           os,
+		Architecture: architecture,
+	}, nil
+
+}
+
+// EncodeJSONResponse is a duplicate of httptransport.EncodeJSONResponse but uses the content-type expected by Terraform
+func EncodeJSONResponse(_ context.Context, w http.ResponseWriter, response interface{}) error {
+	w.Header().Set("Content-Type", "application/json")
+	if headerer, ok := response.(httptransport.Headerer); ok {
+		for k, values := range headerer.Headers() {
+			for _, v := range values {
+				w.Header().Add(k, v)
+			}
+		}
+	}
+	code := http.StatusOK
+	if sc, ok := response.(httptransport.StatusCoder); ok {
+		code = sc.StatusCode()
+	}
+	w.WriteHeader(code)
+	if code == http.StatusNoContent {
+		return nil
+	}
+	return json.NewEncoder(w).Encode(response)
+}
+
+func encodedMirroredResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+	archiveResponse, ok := response.(*retrieveProviderArchiveResponse)
+	if !ok {
+		return errors.New("failed to type assert to retrieveProviderArchiveResponse")
+	}
+
+	w.Header().Set("Location", archiveResponse.location)
+	w.WriteHeader(http.StatusTemporaryRedirect)
+	return nil
+}
+
+func EncodeZipResponse(ctx context.Context, w http.ResponseWriter, response interface{}) error {
+	w.Header().Set("Content-Type", "application/zip")
+	if headerer, ok := response.(httptransport.Headerer); ok {
+		for k, values := range headerer.Headers() {
+			for _, v := range values {
+				w.Header().Add(k, v)
+			}
+		}
+	}
+	code := http.StatusOK
+	if sc, ok := response.(httptransport.StatusCoder); ok {
+		code = sc.StatusCode()
+	}
+	w.WriteHeader(code)
+	if code == http.StatusNoContent {
+		return nil
+	}
+
+	r, ok := response.(io.Reader)
+	if !ok {
+		return fmt.Errorf("response is not of type io.Reader")
+	}
+
+	if _, err := io.Copy(w, r); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// ErrorEncoder translates domain specific errors to HTTP status codes.
+func ErrorEncoder(_ context.Context, err error, w http.ResponseWriter) {
+	var providerErr *core.ProviderError
+	if errors.As(err, &providerErr) {
+		w.WriteHeader(providerErr.StatusCode)
+	} else if errors.Is(err, ErrVarMissing) {
+		w.WriteHeader(http.StatusBadRequest)
+	} else if errors.Is(err, auth.ErrInvalidToken) {
+		w.WriteHeader(http.StatusUnauthorized)
+	} else {
+		w.WriteHeader(http.StatusInternalServerError)
+	}
+
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+
+	_ = json.NewEncoder(w).Encode(struct {
+		Errors []string `json:"errors"`
+	}{
+		Errors: []string{
+			err.Error(),
+		},
+	})
+}
+
+func extractHeaders(keys ...header) httptransport.RequestFunc {
+	return func(ctx context.Context, r *http.Request) context.Context {
+		for _, k := range keys {
+			if v := r.Header.Get(string(k)); v != "" {
+				ctx = context.WithValue(ctx, k, v)
+			}
+		}
+
+		return ctx
+	}
+}
+
+func extractMuxVars(keys ...muxVar) httptransport.RequestFunc {
+	return func(ctx context.Context, r *http.Request) context.Context {
+		for _, k := range keys {
+			if v, ok := mux.Vars(r)[string(k)]; ok {
+				ctx = context.WithValue(ctx, k, v)
+			}
+		}
+
+		return ctx
+	}
+}
+
+func encodeUpstreamArchiveDownloadRequest(_ context.Context, r *http.Request, request interface{}) error {
+	req := request.(retrieveProviderArchiveRequest)
+	var buf bytes.Buffer
+	r.URL.Path = fmt.Sprintf("/v1/providers/%s/%s/%s/download/%s/%s", req.Namespace, req.Name, req.Version, req.OS, req.Architecture)
+	if err := json.NewEncoder(&buf).Encode(request); err != nil {
+		return err
+	}
+	r.Body = io.NopCloser(&buf)
+	return nil
+}
+
+// TODO(oliviermichaelis): rename
+func decodeUpstreamArchiveDownloadResponse(r *http.Response) (*core.Provider, error) {
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code is %d instead of 200", r.StatusCode)
+	}
+
+	var response core.Provider
+	if err := json.NewDecoder(r.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}
+
+type listResponse struct {
+	Versions []listResponseVersion `json:"versions,omitempty"`
+}
+
+func (l *listResponse) providerVersions() *ProviderVersions {
+	transformed := &ProviderVersions{
+		Versions: map[string]EmptyObject{},
+	}
+	for _, version := range l.Versions {
+		transformed.Versions[version.Version] = EmptyObject{}
+	}
+	return transformed
+}
+
+type listResponseVersion struct {
+	Version   string          `json:"version,omitempty"`
+	Protocols []string        `json:"protocols,omitempty"`
+	Platforms []core.Platform `json:"platforms,omitempty"`
+}
+
+func decodeUpstreamListProviderVersionsResponse(r *http.Response) (*listResponse, error) {
+	if r.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("status code is %d instead of 200", r.StatusCode)
+	}
+	// var listResponse struct {
+	// 	Versions []listResponseVersion `json:"versions,omitempty"`
+	// }
+
+	var response listResponse
+	if err := json.NewDecoder(r.Body).Decode(&response); err != nil {
+		return nil, err
+	}
+	return &response, nil
+}

--- a/pkg/mirror/upstream.go
+++ b/pkg/mirror/upstream.go
@@ -11,7 +11,7 @@ import (
 )
 
 type upstreamProvider interface {
-	listProviderVersions(ctx context.Context, provider *core.Provider) (*listResponse, error)
+	listProviderVersions(ctx context.Context, provider *core.Provider) (*core.ProviderVersions, error)
 	getProvider(ctx context.Context, provider *core.Provider) (*core.Provider, error)
 	shaSums(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error)
 }
@@ -21,7 +21,7 @@ type upstreamProviderRegistry struct {
 	remoteServiceDiscovery *discovery.RemoteServiceDiscovery
 }
 
-func (u *upstreamProviderRegistry) listProviderVersions(ctx context.Context, provider *core.Provider) (*listResponse, error) {
+func (u *upstreamProviderRegistry) listProviderVersions(ctx context.Context, provider *core.Provider) (*core.ProviderVersions, error) {
 	discovered, err := u.remoteServiceDiscovery.Resolve(ctx, provider.Hostname)
 	if err != nil {
 		return nil, err
@@ -53,12 +53,12 @@ func (u *upstreamProviderRegistry) getProvider(ctx context.Context, provider *co
 		return nil, err
 	}
 	resp, err := u.client.Do(req)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
-	decoded, err := decodeUpstreamArchiveDownloadResponse(resp)
+	decoded, err := decodeUpstreamProviderResponse(resp)
 	if err != nil {
 		return nil, err
 	}
@@ -78,10 +78,10 @@ func (u *upstreamProviderRegistry) shaSums(ctx context.Context, provider *core.P
 		return nil, err
 	}
 	resp, err := u.client.Do(req)
-	defer resp.Body.Close()
 	if err != nil {
 		return nil, err
 	}
+	defer resp.Body.Close()
 
 	sha256Sums, err := core.NewSha256Sums(provider.ShasumFileName(), resp.Body)
 	if err != nil {

--- a/pkg/mirror/upstream.go
+++ b/pkg/mirror/upstream.go
@@ -1,0 +1,111 @@
+package mirror
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+	"github.com/TierMobility/boring-registry/pkg/discovery"
+)
+
+type upstreamProvider interface {
+	listProviderVersions(ctx context.Context, provider *core.Provider) (*listResponse, error)
+	getProvider(ctx context.Context, provider *core.Provider) (*core.Provider, error)
+	shaSums(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error)
+}
+
+type upstreamProviderRegistry struct {
+	client                 *http.Client
+	remoteServiceDiscovery *discovery.RemoteServiceDiscovery
+}
+
+func (u *upstreamProviderRegistry) listProviderVersions(ctx context.Context, provider *core.Provider) (*listResponse, error) {
+	discovered, err := u.remoteServiceDiscovery.Resolve(ctx, provider.Hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("%s%s/%s/versions", discovered.ProvidersV1, provider.Namespace, provider.Name)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamURL(discovered.URL.Host, path), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := u.client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	return decodeUpstreamListProviderVersionsResponse(resp)
+}
+
+func (u *upstreamProviderRegistry) getProvider(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+	discovered, err := u.remoteServiceDiscovery.Resolve(ctx, provider.Hostname)
+	if err != nil {
+		return nil, err
+	}
+
+	path := fmt.Sprintf("%s%s/%s/%s/download/%s/%s", discovered.ProvidersV1, provider.Namespace, provider.Name, provider.Version, provider.OS, provider.Arch)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, upstreamURL(discovered.URL.Host, path), nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := u.client.Do(req)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	decoded, err := decodeUpstreamArchiveDownloadResponse(resp)
+	if err != nil {
+		return nil, err
+	}
+
+	// Merge provider into decoded to fully populate the struct
+	decoded.Hostname = provider.Hostname
+	decoded.Namespace = provider.Namespace
+	decoded.Name = provider.Name
+	decoded.Version = provider.Version
+
+	return decoded, err
+}
+
+func (u *upstreamProviderRegistry) shaSums(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, provider.SHASumsURL, nil)
+	if err != nil {
+		return nil, err
+	}
+	resp, err := u.client.Do(req)
+	defer resp.Body.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	sha256Sums, err := core.NewSha256Sums(provider.ShasumFileName(), resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse SHA256SUM: %w", err)
+	}
+	return sha256Sums, nil
+}
+
+func newUpstreamProviderRegistry(remoteServiceDiscovery *discovery.RemoteServiceDiscovery) *upstreamProviderRegistry {
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConnsPerHost = 100
+	return &upstreamProviderRegistry{
+		client: &http.Client{
+			Transport: transport,
+		},
+		remoteServiceDiscovery: remoteServiceDiscovery,
+	}
+}
+
+func upstreamURL(hostname, path string) string {
+	upstreamUrl := url.URL{
+		Scheme: "https",
+		Host:   hostname,
+		Path:   path,
+	}
+	return upstreamUrl.String()
+}

--- a/pkg/mirror/upstream.go
+++ b/pkg/mirror/upstream.go
@@ -18,7 +18,7 @@ type upstreamProvider interface {
 
 type upstreamProviderRegistry struct {
 	client                 *http.Client
-	remoteServiceDiscovery *discovery.RemoteServiceDiscovery
+	remoteServiceDiscovery discovery.ServiceDiscoveryResolver
 }
 
 func (u *upstreamProviderRegistry) listProviderVersions(ctx context.Context, provider *core.Provider) (*core.ProviderVersions, error) {
@@ -90,7 +90,7 @@ func (u *upstreamProviderRegistry) shaSums(ctx context.Context, provider *core.P
 	return sha256Sums, nil
 }
 
-func newUpstreamProviderRegistry(remoteServiceDiscovery *discovery.RemoteServiceDiscovery) *upstreamProviderRegistry {
+func newUpstreamProviderRegistry(remoteServiceDiscovery discovery.ServiceDiscoveryResolver) *upstreamProviderRegistry {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.MaxIdleConnsPerHost = 100
 	return &upstreamProviderRegistry{

--- a/pkg/mirror/upstream_test.go
+++ b/pkg/mirror/upstream_test.go
@@ -2,6 +2,7 @@ package mirror
 
 import (
 	"context"
+	"encoding/hex"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -19,6 +20,22 @@ type mockedRemoteServiceDiscovery struct {
 
 func (m *mockedRemoteServiceDiscovery) Resolve(ctx context.Context, host string) (*discovery.DiscoveredRemoteService, error) {
 	return m.resolve(ctx, host)
+}
+
+func newMockedServiceDiscovery(server *httptest.Server) *mockedRemoteServiceDiscovery {
+	return &mockedRemoteServiceDiscovery{
+		resolve: func(ctx context.Context, host string) (*discovery.DiscoveredRemoteService, error) {
+			return &discovery.DiscoveredRemoteService{
+				URL: url.URL{
+					Scheme: "https",
+					Host:   strings.TrimPrefix(server.URL, "https://"),
+				},
+				WellKnownEndpointResponse: discovery.WellKnownEndpointResponse{
+					ProvidersV1: "/v1/providers",
+				},
+			}, nil
+		},
+	}
 }
 
 func Test_upstreamProviderRegistry_listProviderVersions(t *testing.T) {
@@ -67,7 +84,7 @@ func Test_upstreamProviderRegistry_listProviderVersions(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 				writer.WriteHeader(tt.statusCode)
-				if _, err := writer.Write([]byte(`{
+				body := []byte(`{
   "versions": [
     {
       "version": "2.0.0",
@@ -78,27 +95,16 @@ func Test_upstreamProviderRegistry_listProviderVersions(t *testing.T) {
       ]
     }
   ]
-}`)); err != nil {
+}`)
+				if _, err := writer.Write(body); err != nil {
 					panic(err)
 				}
 			}))
-			mockedServiceDiscovery := &mockedRemoteServiceDiscovery{
-				resolve: func(ctx context.Context, host string) (*discovery.DiscoveredRemoteService, error) {
-					return &discovery.DiscoveredRemoteService{
-						URL: url.URL{
-							Scheme: "https",
-							Host:   strings.TrimPrefix(server.URL, "https://"),
-						},
-						WellKnownEndpointResponse: discovery.WellKnownEndpointResponse{
-							ProvidersV1: "/v1/providers",
-						},
-					}, nil
-				},
-			}
 			u := &upstreamProviderRegistry{
 				client:                 server.Client(),
-				remoteServiceDiscovery: mockedServiceDiscovery,
+				remoteServiceDiscovery: newMockedServiceDiscovery(server),
 			}
+
 			got, err := u.listProviderVersions(context.Background(), tt.provider)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("upstreamProviderRegistry.listProviderVersions() error = %v, wantErr %v", err, tt.wantErr)
@@ -106,6 +112,161 @@ func Test_upstreamProviderRegistry_listProviderVersions(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, tt.want) {
 				t.Errorf("upstreamProviderRegistry.listProviderVersions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_upstreamProviderRegistry_getProvider(t *testing.T) {
+	tests := []struct {
+		name       string
+		statusCode int
+		provider   *core.Provider
+		want       *core.Provider
+		wantErr    bool
+	}{
+		{
+			name:       "successfully retrieve provider",
+			statusCode: http.StatusOK,
+			provider: &core.Provider{
+				Hostname:  "terraform.example.com",
+				Namespace: "hashicorp",
+				Name:      "random",
+				Version:   "2.0.0",
+				OS:        "linux",
+				Arch:      "amd64",
+			},
+			want: &core.Provider{
+				Hostname:            "terraform.example.com",
+				Namespace:           "hashicorp",
+				Name:                "random",
+				Version:             "2.0.0",
+				OS:                  "linux",
+				Arch:                "amd64",
+				Filename:            "terraform-provider-random_2.0.0_linux_amd64.zip",
+				DownloadURL:         "https://releases.hashicorp.com/terraform-provider-random/2.0.0/terraform-provider-random_2.0.0_linux_amd64.zip",
+				SHASumsURL:          "https://releases.hashicorp.com/terraform-provider-random/2.0.0/terraform-provider-random_2.0.0_SHA256SUMS",
+				SHASumsSignatureURL: "https://releases.hashicorp.com/terraform-provider-random/2.0.0/terraform-provider-random_2.0.0_SHA256SUMS.sig",
+				Shasum:              "5f9c7aa76b7c34d722fc9123208e26b22d60440cb47150dd04733b9b94f4541a",
+				SigningKeys: core.SigningKeys{
+					GPGPublicKeys: []core.GPGPublicKey{
+						{
+							KeyID:      "51852D87348FFC4C",
+							ASCIIArmor: "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v1\n\nmQENBFMORM0BCADBRyKO1MhCirazOSVwcfTr1xUxjPvfxD3hjUwHtjsOy/bT6p9f\nW2mRPfwnq2JB5As+paL3UGDsSRDnK9KAxQb0NNF4+eVhr/EJ18s3wwXXDMjpIifq\nfIm2WyH3G+aRLTLPIpscUNKDyxFOUbsmgXAmJ46Re1fn8uKxKRHbfa39aeuEYWFA\n3drdL1WoUngvED7f+RnKBK2G6ZEpO+LDovQk19xGjiMTtPJrjMjZJ3QXqPvx5wca\nKSZLr4lMTuoTI/ZXyZy5bD4tShiZz6KcyX27cD70q2iRcEZ0poLKHyEIDAi3TM5k\nSwbbWBFd5RNPOR0qzrb/0p9ksKK48IIfH2FvABEBAAG0K0hhc2hpQ29ycCBTZWN1\ncml0eSA8c2VjdXJpdHlAaGFzaGljb3JwLmNvbT6JATgEEwECACIFAlMORM0CGwMG\nCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEFGFLYc0j/xMyWIIAIPhcVqiQ59n\nJc07gjUX0SWBJAxEG1lKxfzS4Xp+57h2xxTpdotGQ1fZwsihaIqow337YHQI3q0i\nSqV534Ms+j/tU7X8sq11xFJIeEVG8PASRCwmryUwghFKPlHETQ8jJ+Y8+1asRydi\npsP3B/5Mjhqv/uOK+Vy3zAyIpyDOMtIpOVfjSpCplVRdtSTFWBu9Em7j5I2HMn1w\nsJZnJgXKpybpibGiiTtmnFLOwibmprSu04rsnP4ncdC2XRD4wIjoyA+4PKgX3sCO\nklEzKryWYBmLkJOMDdo52LttP3279s7XrkLEE7ia0fXa2c12EQ0f0DQ1tGUvyVEW\nWmJVccm5bq25AQ0EUw5EzQEIANaPUY04/g7AmYkOMjaCZ6iTp9hB5Rsj/4ee/ln9\nwArzRO9+3eejLWh53FoN1rO+su7tiXJA5YAzVy6tuolrqjM8DBztPxdLBbEi4V+j\n2tK0dATdBQBHEh3OJApO2UBtcjaZBT31zrG9K55D+CrcgIVEHAKY8Cb4kLBkb5wM\nskn+DrASKU0BNIV1qRsxfiUdQHZfSqtp004nrql1lbFMLFEuiY8FZrkkQ9qduixo\nmTT6f34/oiY+Jam3zCK7RDN/OjuWheIPGj/Qbx9JuNiwgX6yRj7OE1tjUx6d8g9y\n0H1fmLJbb3WZZbuuGFnK6qrE3bGeY8+AWaJAZ37wpWh1p0cAEQEAAYkBHwQYAQIA\nCQUCUw5EzQIbDAAKCRBRhS2HNI/8TJntCAClU7TOO/X053eKF1jqNW4A1qpxctVc\nz8eTcY8Om5O4f6a/rfxfNFKn9Qyja/OG1xWNobETy7MiMXYjaa8uUx5iFy6kMVaP\n0BXJ59NLZjMARGw6lVTYDTIvzqqqwLxgliSDfSnqUhubGwvykANPO+93BBx89MRG\nunNoYGXtPlhNFrAsB1VR8+EyKLv2HQtGCPSFBhrjuzH3gxGibNDDdFQLxxuJWepJ\nEK1UbTS4ms0NgZ2Uknqn1WRU1Ki7rE4sTy68iZtWpKQXZEJa0IGnuI2sSINGcXCJ\noEIgXTMyCILo34Fa/C6VCm2WBgz9zZO8/rHIiQm1J5zqz0DrDwKBUM9C\n=LYpS\n-----END PGP PUBLIC KEY BLOCK-----",
+							Source:     "HashiCorp",
+							SourceURL:  "https://www.hashicorp.com/security.html",
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.WriteHeader(tt.statusCode)
+				body := []byte(`{
+					"protocols": ["4.0", "5.1"],
+					"os": "linux",
+					"arch": "amd64",
+					"filename": "terraform-provider-random_2.0.0_linux_amd64.zip",
+					"download_url": "https://releases.hashicorp.com/terraform-provider-random/2.0.0/terraform-provider-random_2.0.0_linux_amd64.zip",
+					"shasums_url": "https://releases.hashicorp.com/terraform-provider-random/2.0.0/terraform-provider-random_2.0.0_SHA256SUMS",
+					"shasums_signature_url": "https://releases.hashicorp.com/terraform-provider-random/2.0.0/terraform-provider-random_2.0.0_SHA256SUMS.sig",
+					"shasum": "5f9c7aa76b7c34d722fc9123208e26b22d60440cb47150dd04733b9b94f4541a",
+					"signing_keys": {
+					  "gpg_public_keys": [
+						{
+						  "key_id": "51852D87348FFC4C",
+						  "ascii_armor": "-----BEGIN PGP PUBLIC KEY BLOCK-----\nVersion: GnuPG v1\n\nmQENBFMORM0BCADBRyKO1MhCirazOSVwcfTr1xUxjPvfxD3hjUwHtjsOy/bT6p9f\nW2mRPfwnq2JB5As+paL3UGDsSRDnK9KAxQb0NNF4+eVhr/EJ18s3wwXXDMjpIifq\nfIm2WyH3G+aRLTLPIpscUNKDyxFOUbsmgXAmJ46Re1fn8uKxKRHbfa39aeuEYWFA\n3drdL1WoUngvED7f+RnKBK2G6ZEpO+LDovQk19xGjiMTtPJrjMjZJ3QXqPvx5wca\nKSZLr4lMTuoTI/ZXyZy5bD4tShiZz6KcyX27cD70q2iRcEZ0poLKHyEIDAi3TM5k\nSwbbWBFd5RNPOR0qzrb/0p9ksKK48IIfH2FvABEBAAG0K0hhc2hpQ29ycCBTZWN1\ncml0eSA8c2VjdXJpdHlAaGFzaGljb3JwLmNvbT6JATgEEwECACIFAlMORM0CGwMG\nCwkIBwMCBhUIAgkKCwQWAgMBAh4BAheAAAoJEFGFLYc0j/xMyWIIAIPhcVqiQ59n\nJc07gjUX0SWBJAxEG1lKxfzS4Xp+57h2xxTpdotGQ1fZwsihaIqow337YHQI3q0i\nSqV534Ms+j/tU7X8sq11xFJIeEVG8PASRCwmryUwghFKPlHETQ8jJ+Y8+1asRydi\npsP3B/5Mjhqv/uOK+Vy3zAyIpyDOMtIpOVfjSpCplVRdtSTFWBu9Em7j5I2HMn1w\nsJZnJgXKpybpibGiiTtmnFLOwibmprSu04rsnP4ncdC2XRD4wIjoyA+4PKgX3sCO\nklEzKryWYBmLkJOMDdo52LttP3279s7XrkLEE7ia0fXa2c12EQ0f0DQ1tGUvyVEW\nWmJVccm5bq25AQ0EUw5EzQEIANaPUY04/g7AmYkOMjaCZ6iTp9hB5Rsj/4ee/ln9\nwArzRO9+3eejLWh53FoN1rO+su7tiXJA5YAzVy6tuolrqjM8DBztPxdLBbEi4V+j\n2tK0dATdBQBHEh3OJApO2UBtcjaZBT31zrG9K55D+CrcgIVEHAKY8Cb4kLBkb5wM\nskn+DrASKU0BNIV1qRsxfiUdQHZfSqtp004nrql1lbFMLFEuiY8FZrkkQ9qduixo\nmTT6f34/oiY+Jam3zCK7RDN/OjuWheIPGj/Qbx9JuNiwgX6yRj7OE1tjUx6d8g9y\n0H1fmLJbb3WZZbuuGFnK6qrE3bGeY8+AWaJAZ37wpWh1p0cAEQEAAYkBHwQYAQIA\nCQUCUw5EzQIbDAAKCRBRhS2HNI/8TJntCAClU7TOO/X053eKF1jqNW4A1qpxctVc\nz8eTcY8Om5O4f6a/rfxfNFKn9Qyja/OG1xWNobETy7MiMXYjaa8uUx5iFy6kMVaP\n0BXJ59NLZjMARGw6lVTYDTIvzqqqwLxgliSDfSnqUhubGwvykANPO+93BBx89MRG\nunNoYGXtPlhNFrAsB1VR8+EyKLv2HQtGCPSFBhrjuzH3gxGibNDDdFQLxxuJWepJ\nEK1UbTS4ms0NgZ2Uknqn1WRU1Ki7rE4sTy68iZtWpKQXZEJa0IGnuI2sSINGcXCJ\noEIgXTMyCILo34Fa/C6VCm2WBgz9zZO8/rHIiQm1J5zqz0DrDwKBUM9C\n=LYpS\n-----END PGP PUBLIC KEY BLOCK-----",
+						  "trust_signature": "",
+						  "source": "HashiCorp",
+						  "source_url": "https://www.hashicorp.com/security.html"
+						}
+					  ]
+					}
+				  }
+				  `)
+				if _, err := writer.Write(body); err != nil {
+					panic(err)
+				}
+			}))
+			u := &upstreamProviderRegistry{
+				client:                 server.Client(),
+				remoteServiceDiscovery: newMockedServiceDiscovery(server),
+			}
+
+			got, err := u.getProvider(context.Background(), tt.provider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("upstreamProviderRegistry.getProvider() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("upstreamProviderRegistry.getProvider() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_upstreamProviderRegistry_shaSums(t *testing.T) {
+	tests := []struct {
+		name     string
+		provider *core.Provider
+		want     *core.Sha256Sums
+		wantErr  bool
+	}{
+		{
+			name: "successfully retrieve SHASUMS file",
+			provider: &core.Provider{
+				Hostname:  "terraform.example.com",
+				Namespace: "hashicorp",
+				Name:      "random",
+				Version:   "2.0.0",
+				OS:        "linux",
+				Arch:      "amd64",
+			},
+			want: &core.Sha256Sums{
+				Filename: "terraform-provider-random_2.0.0_SHA256SUMS",
+				Entries: func() map[string][]byte {
+					amd64Sum, err := hex.DecodeString("5f9c7aa76b7c34d722fc9123208e26b22d60440cb47150dd04733b9b94f4541a")
+					if err != nil {
+						panic(err)
+					}
+					armSum, err := hex.DecodeString("29df160b8b618227197cc9984c47412461ad66a300a8fc1db4052398bf5656ac")
+					if err != nil {
+						panic(err)
+					}
+					return map[string][]byte{
+						"terraform-provider-random_2.0.0_linux_amd64.zip": amd64Sum,
+						"terraform-provider-random_2.0.0_linux_arm.zip":   armSum,
+					}
+				}(),
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.WriteHeader(http.StatusOK)
+				body := []byte(`5f9c7aa76b7c34d722fc9123208e26b22d60440cb47150dd04733b9b94f4541a  terraform-provider-random_2.0.0_linux_amd64.zip
+29df160b8b618227197cc9984c47412461ad66a300a8fc1db4052398bf5656ac  terraform-provider-random_2.0.0_linux_arm.zip`)
+				if _, err := writer.Write(body); err != nil {
+					panic(err)
+				}
+			}))
+			u := &upstreamProviderRegistry{
+				client:                 server.Client(),
+				remoteServiceDiscovery: newMockedServiceDiscovery(server),
+			}
+			tt.provider.SHASumsURL = server.URL
+
+			got, err := u.shaSums(context.Background(), tt.provider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("upstreamProviderRegistry.shaSums() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("upstreamProviderRegistry.shaSums() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/mirror/upstream_test.go
+++ b/pkg/mirror/upstream_test.go
@@ -1,0 +1,112 @@
+package mirror
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+	"github.com/TierMobility/boring-registry/pkg/discovery"
+)
+
+type mockedRemoteServiceDiscovery struct {
+	resolve func(ctx context.Context, host string) (*discovery.DiscoveredRemoteService, error)
+}
+
+func (m *mockedRemoteServiceDiscovery) Resolve(ctx context.Context, host string) (*discovery.DiscoveredRemoteService, error) {
+	return m.resolve(ctx, host)
+}
+
+func Test_upstreamProviderRegistry_listProviderVersions(t *testing.T) {
+	tests := []struct {
+		name                   string
+		remoteServiceDiscovery discovery.ServiceDiscoveryResolver
+		statusCode             int
+		provider               *core.Provider
+		want                   *core.ProviderVersions
+		wantErr                bool
+	}{
+		{
+			name: "successfully retrieve upstream responsei",
+			remoteServiceDiscovery: &mockedRemoteServiceDiscovery{
+				resolve: func(ctx context.Context, host string) (*discovery.DiscoveredRemoteService, error) {
+					return &discovery.DiscoveredRemoteService{}, nil
+				},
+			},
+			statusCode: http.StatusOK,
+			provider: &core.Provider{
+				Hostname:  "terraform.example.com",
+				Namespace: "example",
+				Name:      "random",
+			},
+			want: &core.ProviderVersions{
+				Versions: []core.ProviderVersion{
+					{
+						Version:   "2.0.0",
+						Protocols: []string{"4.0", "5.1"},
+						Platforms: []core.Platform{
+							{
+								OS:   "linux",
+								Arch: "amd64",
+							},
+							{
+								OS:   "linux",
+								Arch: "arm",
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewTLSServer(http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
+				writer.WriteHeader(tt.statusCode)
+				if _, err := writer.Write([]byte(`{
+  "versions": [
+    {
+      "version": "2.0.0",
+      "protocols": ["4.0", "5.1"],
+      "platforms": [
+        {"os": "linux", "arch": "amd64"},
+        {"os": "linux", "arch": "arm"}
+      ]
+    }
+  ]
+}`)); err != nil {
+					panic(err)
+				}
+			}))
+			mockedServiceDiscovery := &mockedRemoteServiceDiscovery{
+				resolve: func(ctx context.Context, host string) (*discovery.DiscoveredRemoteService, error) {
+					return &discovery.DiscoveredRemoteService{
+						URL: url.URL{
+							Scheme: "https",
+							Host:   strings.TrimPrefix(server.URL, "https://"),
+						},
+						WellKnownEndpointResponse: discovery.WellKnownEndpointResponse{
+							ProvidersV1: "/v1/providers",
+						},
+					}, nil
+				},
+			}
+			u := &upstreamProviderRegistry{
+				client:                 server.Client(),
+				remoteServiceDiscovery: mockedServiceDiscovery,
+			}
+			got, err := u.listProviderVersions(context.Background(), tt.provider)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("upstreamProviderRegistry.listProviderVersions() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("upstreamProviderRegistry.listProviderVersions() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/module/middleware.go
+++ b/pkg/module/middleware.go
@@ -2,8 +2,9 @@ package module
 
 import (
 	"context"
-	"github.com/TierMobility/boring-registry/pkg/core"
 	"time"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
 
 	"github.com/go-kit/kit/log"
 	"github.com/go-kit/kit/log/level"

--- a/pkg/provider/endpoint.go
+++ b/pkg/provider/endpoint.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/TierMobility/boring-registry/pkg/core"
 
 	"github.com/go-kit/kit/endpoint"
@@ -12,36 +13,11 @@ type listRequest struct {
 	name      string
 }
 
-type listResponse struct {
-	Versions []listResponseVersion `json:"versions,omitempty"`
-}
-
-type listResponseVersion struct {
-	Version   string          `json:"version,omitempty"`
-	Platforms []core.Platform `json:"platforms,omitempty"`
-}
-
 func listEndpoint(svc Service) endpoint.Endpoint {
 	return func(ctx context.Context, request interface{}) (interface{}, error) {
 		req := request.(listRequest)
 
-		res, err := svc.ListProviderVersions(ctx, req.namespace, req.name)
-		if err != nil {
-			return nil, err
-		}
-
-		var versions []listResponseVersion
-
-		for _, provider := range res {
-			versions = append(versions, listResponseVersion{
-				Version:   provider.Version,
-				Platforms: provider.Platforms,
-			})
-		}
-
-		return listResponse{
-			Versions: versions,
-		}, nil
+		return svc.ListProviderVersions(ctx, req.namespace, req.name)
 	}
 }
 

--- a/pkg/provider/errors.go
+++ b/pkg/provider/errors.go
@@ -2,6 +2,10 @@ package provider
 
 import "errors"
 
+var (
+	ErrProviderNotFound = errors.New("failed to locate provider")
+)
+
 // Transport errors.
 var (
 	ErrVarMissing = errors.New("variable missing")

--- a/pkg/provider/middleware.go
+++ b/pkg/provider/middleware.go
@@ -3,11 +3,12 @@ package provider
 import (
 	"context"
 	"fmt"
-	"github.com/TierMobility/boring-registry/pkg/core"
 	"time"
 
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
+	"github.com/TierMobility/boring-registry/pkg/core"
+
+	"github.com/go-kit/log"
+	"github.com/go-kit/log/level"
 )
 
 // Middleware is a Service middleware.
@@ -28,7 +29,7 @@ func LoggingMiddleware(logger log.Logger) Middleware {
 	}
 }
 
-func (mw loggingMiddleware) ListProviderVersions(ctx context.Context, namespace, name string) (providers []core.ProviderVersion, err error) {
+func (mw loggingMiddleware) ListProviderVersions(ctx context.Context, namespace, name string) (versions *core.ProviderVersions, err error) {
 	defer func(begin time.Time) {
 		logger := level.Info(mw.logger)
 		if err != nil {

--- a/pkg/provider/service.go
+++ b/pkg/provider/service.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"context"
+
 	"github.com/TierMobility/boring-registry/pkg/core"
 )
 
@@ -9,7 +10,7 @@ import (
 // For more information see: https://www.terraform.io/docs/internals/provider-registry-protocol.html.
 type Service interface {
 	GetProvider(ctx context.Context, namespace, name, version, os, arch string) (core.Provider, error)
-	ListProviderVersions(ctx context.Context, namespace, name string) ([]core.ProviderVersion, error)
+	ListProviderVersions(ctx context.Context, namespace, name string) (*core.ProviderVersions, error)
 }
 
 type service struct {
@@ -24,19 +25,9 @@ func NewService(storage Storage) Service {
 }
 
 func (s *service) GetProvider(ctx context.Context, namespace, name, version, os, arch string) (core.Provider, error) {
-	res, err := s.storage.GetProvider(ctx, namespace, name, version, os, arch)
-	if err != nil {
-		return core.Provider{}, err
-	}
-
-	return res, nil
+	return s.storage.GetProvider(ctx, namespace, name, version, os, arch)
 }
 
-func (s *service) ListProviderVersions(ctx context.Context, namespace, name string) ([]core.ProviderVersion, error) {
-	res, err := s.storage.ListProviderVersions(ctx, namespace, name)
-	if err != nil {
-		return nil, err
-	}
-
-	return res, nil
+func (s *service) ListProviderVersions(ctx context.Context, namespace, name string) (*core.ProviderVersions, error) {
+	return s.storage.ListProviderVersions(ctx, namespace, name)
 }

--- a/pkg/provider/storage.go
+++ b/pkg/provider/storage.go
@@ -6,13 +6,13 @@ import (
 
 	"github.com/TierMobility/boring-registry/pkg/core"
 
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 )
 
 // Storage represents the Storage of Terraform providers.
 type Storage interface {
 	GetProvider(ctx context.Context, namespace, name, version, os, arch string) (core.Provider, error)
-	ListProviderVersions(ctx context.Context, namespace, name string) ([]core.ProviderVersion, error)
+	ListProviderVersions(ctx context.Context, namespace, name string) (*core.ProviderVersions, error)
 
 	// UploadProviderReleaseFiles is used to upload all artifacts which make up a provider release
 	// https://developer.hashicorp.com/terraform/registry/providers/publishing#manually-preparing-a-release

--- a/pkg/storage/collection.go
+++ b/pkg/storage/collection.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+
 	"github.com/TierMobility/boring-registry/pkg/core"
 )
 
@@ -15,14 +16,14 @@ func NewCollection() *Collection {
 	}
 }
 
-func (s *Collection) List() []core.ProviderVersion {
-	var out []core.ProviderVersion
+func (s *Collection) List() *core.ProviderVersions {
+	var out core.ProviderVersions
 
 	for _, provider := range s.m {
-		out = append(out, provider)
+		out.Versions = append(out.Versions, provider)
 	}
 
-	return out
+	return &out
 }
 
 func (s *Collection) Add(provider core.Provider) {

--- a/pkg/storage/collection.go
+++ b/pkg/storage/collection.go
@@ -26,7 +26,7 @@ func (s *Collection) List() *core.ProviderVersions {
 	return &out
 }
 
-func (s *Collection) Add(provider core.Provider) {
+func (s *Collection) Add(provider *core.Provider) {
 	id := fmt.Sprintf("%s/%s/%s", provider.Namespace, provider.Name, provider.Version)
 
 	if _, ok := s.m[id]; !ok {

--- a/pkg/storage/errors.go
+++ b/pkg/storage/errors.go
@@ -1,9 +1,16 @@
 package storage
 
-import "errors"
+import (
+	"errors"
+	"net/http"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+)
 
 // Storage errors.
 var (
+	ErrObjectAlreadyExists = errors.New("object already exists")
+
 	// module errors
 	ErrModuleUploadFailed  = errors.New("failed to upload module")
 	ErrModuleAlreadyExists = errors.New("module already exists")
@@ -20,3 +27,11 @@ var (
 var (
 	ErrVarMissing = errors.New("variable missing")
 )
+
+func noMatchingProviderFound(provider *core.Provider) error {
+	return &core.ProviderError{
+		Reason:     "failed to find matching providers",
+		Provider:   provider,
+		StatusCode: http.StatusNotFound,
+	}
+}

--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -3,8 +3,10 @@ package storage
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
+	"net/http"
 	"path"
 	"path/filepath"
 	"time"
@@ -14,7 +16,7 @@ import (
 	credentials "cloud.google.com/go/iam/credentials/apiv1"
 	"cloud.google.com/go/iam/credentials/apiv1/credentialspb"
 	"cloud.google.com/go/storage"
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 	"golang.org/x/oauth2/google"
 	"google.golang.org/api/iterator"
@@ -64,7 +66,7 @@ func (s *GCSStorage) ListModuleVersions(ctx context.Context, namespace, name, pr
 	it := s.sc.Bucket(s.bucket).Objects(ctx, query)
 	for {
 		attrs, err := it.Next()
-		if err == iterator.Done {
+		if errors.Is(err, iterator.Done) {
 			break
 		}
 		if err != nil {
@@ -188,68 +190,74 @@ func (s *GCSStorage) MigrateProviders(ctx context.Context, logger log.Logger, dr
 }
 
 // GetProvider implements provider.Storage
-func (s *GCSStorage) GetProvider(ctx context.Context, namespace, name, version, os, arch string) (core.Provider, error) {
-	archivePath, shasumPath, shasumSigPath, err := internalProviderPath(s.bucketPrefix, namespace, name, version, os, arch)
-	if err != nil {
-		return core.Provider{}, err
+func (s *GCSStorage) getProvider(ctx context.Context, pt providerType, provider *core.Provider) (*core.Provider, error) {
+	var archivePath, shasumPath, shasumSigPath string
+	if pt == internalProviderType {
+		archivePath, shasumPath, shasumSigPath = internalProviderPath(s.bucketPrefix, provider.Namespace, provider.Name, provider.Version, provider.OS, provider.Arch)
+	} else if pt == mirrorProviderType {
+		archivePath, shasumPath, shasumSigPath = mirrorProviderPath(s.bucketPrefix, provider.Hostname, provider.Namespace, provider.Name, provider.Version, provider.OS, provider.Arch)
 	}
 
-	pathSigningKeys := signingKeysPath(s.bucketPrefix, namespace)
-
-	zipURL, err := s.presignedURL(ctx, archivePath)
-	if err != nil {
-		return core.Provider{}, err
-	}
-	shasumsURL, err := s.presignedURL(ctx, shasumPath)
-	if err != nil {
-		return core.Provider{}, errors.Wrap(err, shasumPath)
-	}
-	signatureURL, err := s.presignedURL(ctx, shasumSigPath)
-	if err != nil {
-		return core.Provider{}, err
+	if exists, err := s.objectExists(ctx, archivePath); err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, &core.ProviderError{
+			Reason:     "failed to locate provider",
+			Provider:   provider,
+			StatusCode: http.StatusNotFound,
+		}
 	}
 
-	signingKeysRaw, err := s.download(ctx, pathSigningKeys)
+	var err error
+	provider.DownloadURL, err = s.presignedURL(ctx, archivePath)
 	if err != nil {
-		return core.Provider{}, errors.Wrap(err, pathSigningKeys)
+		return nil, fmt.Errorf("failed to create pre-signed url for %s: %w", archivePath, err)
 	}
-
-	signingKeys, err := unmarshalSigningKeys(signingKeysRaw)
+	provider.SHASumsURL, err = s.presignedURL(ctx, shasumPath)
 	if err != nil {
-		return core.Provider{}, err
+		return nil, fmt.Errorf("failed to create pre-signed url for %s: %w", archivePath, err)
+	}
+	provider.SHASumsSignatureURL, err = s.presignedURL(ctx, shasumSigPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create pre-signed url for %s: %w", archivePath, err)
 	}
 
 	shasumBytes, err := s.download(ctx, shasumPath)
 	if err != nil {
-		return core.Provider{}, err
+		return nil, err
 	}
 
-	shasum, err := readSHASums(bytes.NewReader(shasumBytes), path.Base(archivePath))
+	provider.Shasum, err = readSHASums(bytes.NewReader(shasumBytes), path.Base(archivePath))
 	if err != nil {
-		return core.Provider{}, err
+		return nil, err
 	}
-
-	return core.Provider{
-		Namespace:           namespace,
-		Filename:            path.Base(archivePath),
-		Name:                name,
-		Version:             version,
-		OS:                  os,
-		Arch:                arch,
-		Shasum:              shasum,
-		DownloadURL:         zipURL,
-		SHASumsURL:          shasumsURL,
-		SHASumsSignatureURL: signatureURL,
-		SigningKeys:         *signingKeys,
-	}, nil
-}
-
-func (s *GCSStorage) ListProviderVersions(ctx context.Context, namespace, name string) ([]core.ProviderVersion, error) {
-	prefix, err := providerStoragePrefix(s.bucketPrefix, internalProviderType, "", namespace, name)
+	signingKeys, err := s.SigningKeys(ctx, provider.Namespace)
 	if err != nil {
 		return nil, err
 	}
 
+	provider.Filename = path.Base(archivePath)
+	provider.SigningKeys = *signingKeys
+	return provider, nil
+}
+
+func (s *GCSStorage) GetProvider(ctx context.Context, namespace, name, version, os, arch string) (core.Provider, error) {
+	p, err := s.getProvider(ctx, internalProviderType, &core.Provider{
+		Namespace: namespace,
+		Name:      name,
+		Version:   version,
+		OS:        os,
+		Arch:      arch,
+	})
+	return *p, err
+}
+
+func (s *GCSStorage) GetMirroredProvider(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+	return s.getProvider(ctx, mirrorProviderType, provider)
+}
+
+func (s *GCSStorage) listProviderVersions(ctx context.Context, pt providerType, provider *core.Provider) (*core.ProviderVersions, error) {
+	prefix := providerStoragePrefix(s.bucketPrefix, pt, provider.Hostname, provider.Namespace, provider.Name)
 	query := &storage.Query{
 		Prefix: fmt.Sprintf("%s/", prefix),
 	}
@@ -272,21 +280,34 @@ func (s *GCSStorage) ListProviderVersions(ctx context.Context, namespace, name s
 			return nil, err
 		}
 
-		provider, err := core.NewProviderFromArchive(attrs.Name)
+		p, err := core.NewProviderFromArchive(attrs.Name)
 		if err != nil {
 			continue
 		}
 
-		collection.Add(provider)
+		if provider.Version != "" && provider.Version != p.Version {
+			// The provider version doesn't match the requested version
+			continue
+		}
+
+		collection.Add(p)
 	}
 
 	result := collection.List()
 
-	if len(result) == 0 {
-		return nil, fmt.Errorf("no provider versions found for %s/%s", namespace, name)
+	if len(result.Versions) == 0 {
+		return nil, noMatchingProviderFound(provider)
 	}
 
 	return result, nil
+}
+
+func (s *GCSStorage) ListProviderVersions(ctx context.Context, namespace, name string) (*core.ProviderVersions, error) {
+	return s.listProviderVersions(ctx, internalProviderType, &core.Provider{Namespace: namespace, Name: name})
+}
+
+func (s *GCSStorage) ListMirroredProviderVersions(ctx context.Context, provider *core.Provider) (*core.ProviderVersions, error) {
+	return s.listProviderVersions(ctx, mirrorProviderType, provider)
 }
 
 func (s *GCSStorage) UploadProviderReleaseFiles(ctx context.Context, namespace, name, filename string, file io.Reader) error {
@@ -302,37 +323,30 @@ func (s *GCSStorage) UploadProviderReleaseFiles(ctx context.Context, namespace, 
 		return fmt.Errorf("name argument is empty")
 	}
 
-	prefix, err := providerStoragePrefix(s.bucketPrefix, internalProviderType, "", namespace, name)
-	if err != nil {
-		return err
-	}
-
+	prefix := providerStoragePrefix(s.bucketPrefix, internalProviderType, "", namespace, name)
 	key := filepath.Join(prefix, filename)
-	exists, err := s.objectExists(ctx, key)
-	if err != nil {
-		return err
-	} else if exists {
-		return ErrProviderAlreadyExists
-	}
-
-	wc := s.sc.Bucket(s.bucket).Object(key).NewWriter(ctx)
-	if _, err := io.Copy(wc, file); err != nil {
-		return fmt.Errorf("failed to upload provider: %w", err)
-	}
-	if err := wc.Close(); err != nil {
-		return fmt.Errorf("failed to upload provider: %w", err)
-	}
-
-	return nil
+	return s.upload(ctx, key, file, false)
 }
 
-// SigningKeys downloads the JSON placed in the namespace in GCS and unmarshals it into a core.SigningKeys
-func (s *GCSStorage) SigningKeys(ctx context.Context, namespace string) (*core.SigningKeys, error) {
+func (s *GCSStorage) UploadMirroredFile(ctx context.Context, provider *core.Provider, fileName string, reader io.Reader) error {
+	prefix := providerStoragePrefix(s.bucketPrefix, mirrorProviderType, provider.Hostname, provider.Namespace, provider.Name)
+
+	key := filepath.Join(prefix, fileName)
+	return s.upload(ctx, key, reader, true)
+}
+
+func (s *GCSStorage) signingKeys(ctx context.Context, pt providerType, hostname, namespace string) (*core.SigningKeys, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace argument is empty")
 	}
-
-	signingKeysRaw, err := s.download(ctx, signingKeysPath(s.bucketPrefix, namespace))
+	key := signingKeysPath(s.bucketPrefix, pt, hostname, namespace)
+	exists, err := s.objectExists(ctx, key)
+	if err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, core.ErrObjectNotFound
+	}
+	signingKeysRaw, err := s.download(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download signing_keys for namespace %s: %w", namespace, err)
 	}
@@ -340,8 +354,61 @@ func (s *GCSStorage) SigningKeys(ctx context.Context, namespace string) (*core.S
 	return unmarshalSigningKeys(signingKeysRaw)
 }
 
-func (s *GCSStorage) download(ctx context.Context, path string) ([]byte, error) {
-	r, err := s.sc.Bucket(s.bucket).Object(path).NewReader(ctx)
+// SigningKeys downloads the JSON placed in the namespace in GCS and unmarshals it into a core.SigningKeys
+func (s *GCSStorage) SigningKeys(ctx context.Context, namespace string) (*core.SigningKeys, error) {
+	return s.signingKeys(ctx, internalProviderType, "", namespace)
+}
+
+func (s *GCSStorage) MirroredSigningKeys(ctx context.Context, hostname, namespace string) (*core.SigningKeys, error) {
+	return s.signingKeys(ctx, mirrorProviderType, hostname, namespace)
+}
+
+func (s *GCSStorage) uploadSigningKeys(ctx context.Context, pt providerType, hostname, namespace string, signingKeys *core.SigningKeys) error {
+	b, err := json.Marshal(signingKeys)
+	if err != nil {
+		return err
+	}
+	key := signingKeysPath(s.bucketPrefix, pt, hostname, namespace)
+	return s.upload(ctx, key, bytes.NewReader(b), true)
+}
+
+func (s *GCSStorage) UploadMirroredSigningKeys(ctx context.Context, hostname, namespace string, signingKeys *core.SigningKeys) error {
+	return s.uploadSigningKeys(ctx, mirrorProviderType, hostname, namespace, signingKeys)
+}
+
+func (s *GCSStorage) MirroredSha256Sum(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error) {
+	prefix := providerStoragePrefix(s.bucketPrefix, mirrorProviderType, provider.Hostname, provider.Namespace, provider.Name)
+	key := filepath.Join(prefix, provider.ShasumFileName())
+	shaSumBytes, err := s.download(ctx, key)
+	if err != nil {
+		return nil, errors.New("failed to download SHA256SUMS")
+	}
+	return core.NewSha256Sums(provider.ShasumFileName(), bytes.NewReader(shaSumBytes))
+}
+
+func (s *GCSStorage) upload(ctx context.Context, key string, reader io.Reader, overwrite bool) error {
+	if !overwrite {
+		exists, err := s.objectExists(ctx, key)
+		if err != nil {
+			return err
+		} else if exists {
+			return ErrObjectAlreadyExists
+		}
+	}
+
+	wc := s.sc.Bucket(s.bucket).Object(key).NewWriter(ctx)
+	if _, err := io.Copy(wc, reader); err != nil {
+		return fmt.Errorf("failed to upload object: %w", err)
+	}
+	if err := wc.Close(); err != nil {
+		return fmt.Errorf("failed to upload object: %w", err)
+	}
+
+	return nil
+}
+
+func (s *GCSStorage) download(ctx context.Context, key string) ([]byte, error) {
+	r, err := s.sc.Bucket(s.bucket).Object(key).NewReader(ctx)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/gcs.go
+++ b/pkg/storage/gcs.go
@@ -231,7 +231,13 @@ func (s *GCSStorage) getProvider(ctx context.Context, pt providerType, provider 
 	if err != nil {
 		return nil, err
 	}
-	signingKeys, err := s.SigningKeys(ctx, provider.Namespace)
+
+	var signingKeys *core.SigningKeys
+	if pt == internalProviderType {
+		signingKeys, err = s.SigningKeys(ctx, provider.Namespace)
+	} else if pt == mirrorProviderType {
+		signingKeys, err = s.MirroredSigningKeys(ctx, provider.Hostname, provider.Namespace)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/path.go
+++ b/pkg/storage/path.go
@@ -58,7 +58,6 @@ func internalProviderPath(prefix, namespace, name, version, os, arch string) (st
 	return providerPath(prefix, internalProviderType, "", namespace, name, version, os, arch)
 }
 
-// TODO(oliviermichaelis): consider using /mirror/providers/<hostname>
 // mirrorProviderPath returns a full path to a mirrored provider archive
 func mirrorProviderPath(prefix, hostname, namespace, name, version, os, arch string) (string, string, string) {
 	return providerPath(prefix, mirrorProviderType, hostname, namespace, name, version, os, arch)

--- a/pkg/storage/path.go
+++ b/pkg/storage/path.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	internalProviderType = providerType("providers")
-	mirrorProviderType   = providerType("mirror")
+	mirrorProviderType   = providerType("mirror/providers")
 	internalModuleType   = moduleType("modules")
 )
 

--- a/pkg/storage/path.go
+++ b/pkg/storage/path.go
@@ -20,7 +20,7 @@ type providerType string
 type moduleType string
 
 // providerStoragePrefix returns a prefix in the form of either <prefix>/providers/<namespace>/<name>
-// or <prefix>/mirror/<hostname>/<namespace>/<name> prefix
+// or <prefix>/mirror/providers/<hostname>/<namespace>/<name> prefix
 func providerStoragePrefix(prefix string, t providerType, hostname, namespace, name string) string {
 	if t == mirrorProviderType && hostname == "" {
 		panic("hostname must not be empty for mirrored provider storage")

--- a/pkg/storage/path_test.go
+++ b/pkg/storage/path_test.go
@@ -1,10 +1,11 @@
 package storage
 
 import (
-	"github.com/TierMobility/boring-registry/pkg/core"
-	"github.com/stretchr/testify/assert"
 	"strings"
 	"testing"
+
+	"github.com/TierMobility/boring-registry/pkg/core"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestProviderPath(t *testing.T) {
@@ -62,9 +63,9 @@ func TestProviderPath(t *testing.T) {
 			os:                "linux",
 			arch:              "amd64",
 			expectedPanic:     false,
-			expectedArchive:   "storagePrefix/mirror/registry.terraform.io/hashicorp/random/terraform-provider-random_3.1.0_linux_amd64.zip",
-			expectedShasum:    "storagePrefix/mirror/registry.terraform.io/hashicorp/random/terraform-provider-random_3.1.0_SHA256SUMS",
-			expectedShasumSig: "storagePrefix/mirror/registry.terraform.io/hashicorp/random/terraform-provider-random_3.1.0_SHA256SUMS.sig",
+			expectedArchive:   "storagePrefix/mirror/providers/registry.terraform.io/hashicorp/random/terraform-provider-random_3.1.0_linux_amd64.zip",
+			expectedShasum:    "storagePrefix/mirror/providers/registry.terraform.io/hashicorp/random/terraform-provider-random_3.1.0_SHA256SUMS",
+			expectedShasumSig: "storagePrefix/mirror/providers/registry.terraform.io/hashicorp/random/terraform-provider-random_3.1.0_SHA256SUMS.sig",
 		},
 		{
 			annotation:        "all parameters for internal storage are set",
@@ -126,7 +127,7 @@ func TestSigningKeysPath(t *testing.T) {
 			pt:         mirrorProviderType,
 			hostname:   "terraform.example.com",
 			namespace:  "hashicorp",
-			expected:   "prefix/mirror/terraform.example.com/hashicorp/signing-keys.json",
+			expected:   "prefix/mirror/providers/terraform.example.com/hashicorp/signing-keys.json",
 		},
 	}
 

--- a/pkg/storage/path_test.go
+++ b/pkg/storage/path_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 )
 
-func TestInternalProviderStoragePrefix(t *testing.T) {
+func TestProviderPath(t *testing.T) {
 	t.Parallel()
 
 	testCase := []struct {
@@ -20,27 +20,27 @@ func TestInternalProviderStoragePrefix(t *testing.T) {
 		version           string
 		os                string
 		arch              string
-		expectedError     bool
+		expectedPanic     bool
 		expectedArchive   string
 		expectedShasum    string
 		expectedShasumSig string
 	}{
 		{
 			annotation:    "every input is missing",
-			expectedError: true,
+			expectedPanic: true,
 		},
 		{
 			annotation:    "only prefix is passed",
 			prefix:        "storage",
 			providerType:  internalProviderType,
-			expectedError: true,
+			expectedPanic: true,
 		},
 		{
 			annotation:    "mirror type and hostname is missing",
 			prefix:        "storage",
 			providerType:  mirrorProviderType,
 			hostname:      "",
-			expectedError: true,
+			expectedPanic: true,
 		},
 		{
 			annotation:    "mirror type and hostname is missing",
@@ -49,7 +49,7 @@ func TestInternalProviderStoragePrefix(t *testing.T) {
 			hostname:      "registry.terraform.io",
 			namespace:     "hashicorp",
 			name:          "",
-			expectedError: true,
+			expectedPanic: true,
 		},
 		{
 			annotation:        "all parameters for mirror storage are set",
@@ -61,7 +61,7 @@ func TestInternalProviderStoragePrefix(t *testing.T) {
 			version:           "3.1.0",
 			os:                "linux",
 			arch:              "amd64",
-			expectedError:     false,
+			expectedPanic:     false,
 			expectedArchive:   "storagePrefix/mirror/registry.terraform.io/hashicorp/random/terraform-provider-random_3.1.0_linux_amd64.zip",
 			expectedShasum:    "storagePrefix/mirror/registry.terraform.io/hashicorp/random/terraform-provider-random_3.1.0_SHA256SUMS",
 			expectedShasumSig: "storagePrefix/mirror/registry.terraform.io/hashicorp/random/terraform-provider-random_3.1.0_SHA256SUMS.sig",
@@ -76,7 +76,7 @@ func TestInternalProviderStoragePrefix(t *testing.T) {
 			version:           "3.1.0",
 			os:                "linux",
 			arch:              "amd64",
-			expectedError:     false,
+			expectedPanic:     false,
 			expectedArchive:   "storagePrefix/providers/hashicorp/random/terraform-provider-random_3.1.0_linux_amd64.zip",
 			expectedShasum:    "storagePrefix/providers/hashicorp/random/terraform-provider-random_3.1.0_SHA256SUMS",
 			expectedShasumSig: "storagePrefix/providers/hashicorp/random/terraform-provider-random_3.1.0_SHA256SUMS.sig",
@@ -86,14 +86,15 @@ func TestInternalProviderStoragePrefix(t *testing.T) {
 	for _, tc := range testCase {
 		tc := tc
 		t.Run(tc.annotation, func(t *testing.T) {
-			archive, shasum, shasumSig, err := providerPath(tc.prefix, tc.providerType, tc.hostname, tc.namespace, tc.name, tc.version, tc.os, tc.arch)
-			if !tc.expectedError {
-				assert.NoError(t, err)
-			} else {
-				assert.Error(t, err)
-				return
-			}
+			defer func() {
+				if tc.expectedPanic {
+					if r := recover(); r == nil {
+						t.Errorf("The code did not panic")
+					}
+				}
+			}()
 
+			archive, shasum, shasumSig := providerPath(tc.prefix, tc.providerType, tc.hostname, tc.namespace, tc.name, tc.version, tc.os, tc.arch)
 			assert.Equal(t, tc.expectedArchive, archive)
 			assert.Equal(t, tc.expectedShasum, shasum)
 			assert.Equal(t, tc.expectedShasumSig, shasumSig)
@@ -107,21 +108,32 @@ func TestSigningKeysPath(t *testing.T) {
 	testCase := []struct {
 		annotation string
 		prefix     string
+		pt         providerType
+		hostname   string
 		namespace  string
 		expected   string
 	}{
 		{
-			annotation: "with prefix and namespace",
+			annotation: "internal keys with prefix and namespace",
 			prefix:     "prefix",
+			pt:         internalProviderType,
 			namespace:  "hashicorp",
 			expected:   "prefix/providers/hashicorp/signing-keys.json",
+		},
+		{
+			annotation: "mirrored keys with prefix and namespace",
+			prefix:     "prefix",
+			pt:         mirrorProviderType,
+			hostname:   "terraform.example.com",
+			namespace:  "hashicorp",
+			expected:   "prefix/mirror/terraform.example.com/hashicorp/signing-keys.json",
 		},
 	}
 
 	for _, tc := range testCase {
 		tc := tc
 		t.Run(tc.annotation, func(t *testing.T) {
-			result := signingKeysPath(tc.prefix, tc.namespace)
+			result := signingKeysPath(tc.prefix, tc.pt, tc.hostname, tc.namespace)
 			assert.Equal(t, tc.expected, result)
 		})
 	}

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -281,7 +281,12 @@ func (s *S3Storage) getProvider(ctx context.Context, pt providerType, provider *
 		return nil, err
 	}
 
-	signingKeys, err := s.SigningKeys(ctx, provider.Namespace)
+	var signingKeys *core.SigningKeys
+	if pt == internalProviderType {
+		signingKeys, err = s.SigningKeys(ctx, provider.Namespace)
+	} else if pt == mirrorProviderType {
+		signingKeys, err = s.MirroredSigningKeys(ctx, provider.Hostname, provider.Namespace)
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/storage/s3.go
+++ b/pkg/storage/s3.go
@@ -3,6 +3,7 @@ package storage
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,7 +19,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/go-kit/kit/log"
+	"github.com/go-kit/log"
 	"github.com/pkg/errors"
 )
 
@@ -238,60 +239,76 @@ func (s *S3Storage) MigrateProviders(ctx context.Context, logger log.Logger, dry
 }
 
 // GetProvider retrieves information about a provider from the S3 storage.
-func (s *S3Storage) GetProvider(ctx context.Context, namespace, name, version, os, arch string) (core.Provider, error) {
-	archivePath, shasumPath, shasumSigPath, err := internalProviderPath(s.bucketPrefix, namespace, name, version, os, arch)
-	if err != nil {
-		return core.Provider{}, err
+func (s *S3Storage) getProvider(ctx context.Context, pt providerType, provider *core.Provider) (*core.Provider, error) {
+	var archivePath, shasumPath, shasumSigPath string
+	if pt == internalProviderType {
+		archivePath, shasumPath, shasumSigPath = internalProviderPath(s.bucketPrefix, provider.Namespace, provider.Name, provider.Version, provider.OS, provider.Arch)
+	} else if pt == mirrorProviderType {
+		archivePath, shasumPath, shasumSigPath = mirrorProviderPath(s.bucketPrefix, provider.Hostname, provider.Namespace, provider.Name, provider.Version, provider.OS, provider.Arch)
 	}
 
-	zipURL, err := s.presignedURL(ctx, archivePath)
-	if err != nil {
-		return core.Provider{}, err
+	if exists, err := s.objectExists(ctx, archivePath); err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, &core.ProviderError{
+			Reason:     "failed to locate provider",
+			Provider:   provider,
+			StatusCode: http.StatusNotFound,
+		}
 	}
-	shasumsURL, err := s.presignedURL(ctx, shasumPath)
+
+	var err error
+	provider.DownloadURL, err = s.presignedURL(ctx, archivePath)
 	if err != nil {
-		return core.Provider{}, errors.Wrap(err, shasumPath)
+		return nil, err
 	}
-	signatureURL, err := s.presignedURL(ctx, shasumSigPath)
+	provider.SHASumsURL, err = s.presignedURL(ctx, shasumPath)
 	if err != nil {
-		return core.Provider{}, err
+		return nil, errors.Wrap(err, shasumPath)
+	}
+	provider.SHASumsSignatureURL, err = s.presignedURL(ctx, shasumSigPath)
+	if err != nil {
+		return nil, err
 	}
 
 	shasumBytes, err := s.download(ctx, shasumPath)
 	if err != nil {
-		return core.Provider{}, err
+		return nil, err
 	}
 
-	shasum, err := readSHASums(bytes.NewReader(shasumBytes), path.Base(archivePath))
-	if err != nil {
-		return core.Provider{}, err
-	}
-
-	signingKeys, err := s.SigningKeys(ctx, namespace)
-	if err != nil {
-		return core.Provider{}, err
-	}
-
-	return core.Provider{
-		Namespace:           namespace,
-		Name:                name,
-		Version:             version,
-		OS:                  os,
-		Arch:                arch,
-		Shasum:              shasum,
-		Filename:            path.Base(archivePath),
-		DownloadURL:         zipURL,
-		SHASumsURL:          shasumsURL,
-		SHASumsSignatureURL: signatureURL,
-		SigningKeys:         *signingKeys,
-	}, nil
-}
-
-func (s *S3Storage) ListProviderVersions(ctx context.Context, namespace, name string) ([]core.ProviderVersion, error) {
-	prefix, err := providerStoragePrefix(s.bucketPrefix, internalProviderType, "", namespace, name)
+	provider.Shasum, err = readSHASums(bytes.NewReader(shasumBytes), path.Base(archivePath))
 	if err != nil {
 		return nil, err
 	}
+
+	signingKeys, err := s.SigningKeys(ctx, provider.Namespace)
+	if err != nil {
+		return nil, err
+	}
+
+	provider.Filename = path.Base(archivePath)
+	provider.SigningKeys = *signingKeys
+	return provider, nil
+}
+
+func (s *S3Storage) GetProvider(ctx context.Context, namespace, name, version, os, arch string) (core.Provider, error) {
+	p, err := s.getProvider(ctx, internalProviderType, &core.Provider{
+		Namespace: namespace,
+		Name:      name,
+		Version:   version,
+		OS:        os,
+		Arch:      arch,
+	})
+
+	return *p, err
+}
+
+func (s *S3Storage) GetMirroredProvider(ctx context.Context, provider *core.Provider) (*core.Provider, error) {
+	return s.getProvider(ctx, mirrorProviderType, provider)
+}
+
+func (s *S3Storage) listProviderVersions(ctx context.Context, pt providerType, provider *core.Provider) (*core.ProviderVersions, error) {
+	prefix := providerStoragePrefix(s.bucketPrefix, pt, provider.Hostname, provider.Namespace, provider.Name)
 
 	input := &s3.ListObjectsV2Input{
 		Bucket: aws.String(s.bucket),
@@ -300,6 +317,7 @@ func (s *S3Storage) ListProviderVersions(ctx context.Context, namespace, name st
 
 	collection := NewCollection()
 	paginator := s3.NewListObjectsV2Paginator(s.client, input)
+
 	for paginator.HasMorePages() {
 		resp, err := paginator.NextPage(ctx)
 		if err != nil {
@@ -307,22 +325,35 @@ func (s *S3Storage) ListProviderVersions(ctx context.Context, namespace, name st
 		}
 
 		for _, obj := range resp.Contents {
-			provider, err := core.NewProviderFromArchive(*obj.Key)
+			p, err := core.NewProviderFromArchive(filepath.Base(*obj.Key))
 			if err != nil {
 				continue
 			}
 
-			collection.Add(provider)
+			if provider.Version != "" && provider.Version != p.Version {
+				// The provider version doesn't match the requested version
+				continue
+			}
+			p.Namespace = provider.Namespace
+			collection.Add(p)
 		}
 	}
 
 	result := collection.List()
 
-	if len(result) == 0 {
-		return nil, fmt.Errorf("no provider versions found for %s/%s", namespace, name)
+	if len(result.Versions) == 0 {
+		return nil, noMatchingProviderFound(provider)
 	}
 
 	return result, nil
+}
+
+func (s *S3Storage) ListProviderVersions(ctx context.Context, namespace, name string) (*core.ProviderVersions, error) {
+	return s.listProviderVersions(ctx, internalProviderType, &core.Provider{Namespace: namespace, Name: name})
+}
+
+func (s *S3Storage) ListMirroredProviderVersions(ctx context.Context, provider *core.Provider) (*core.ProviderVersions, error) {
+	return s.listProviderVersions(ctx, mirrorProviderType, provider)
 }
 
 func (s *S3Storage) UploadProviderReleaseFiles(ctx context.Context, namespace, name, filename string, file io.Reader) error {
@@ -338,44 +369,68 @@ func (s *S3Storage) UploadProviderReleaseFiles(ctx context.Context, namespace, n
 		return fmt.Errorf("name argument is empty")
 	}
 
-	prefix, err := providerStoragePrefix(s.bucketPrefix, internalProviderType, "", namespace, name)
-	if err != nil {
-		return err
-	}
-
+	prefix := providerStoragePrefix(s.bucketPrefix, internalProviderType, "", namespace, name)
 	key := filepath.Join(prefix, filename)
-	exists, err := s.objectExists(ctx, key)
-	if err != nil {
-		return err
-	} else if exists {
-		return ErrProviderAlreadyExists
-	}
-
-	input := &s3.PutObjectInput{
-		Bucket: aws.String(s.bucket),
-		Key:    aws.String(key),
-		Body:   file,
-	}
-
-	if _, err = s.uploader.Upload(ctx, input); err != nil {
-		return fmt.Errorf("failed to upload provider: %w", err)
-	}
-
-	return nil
+	return s.upload(ctx, key, file, false)
 }
 
-// SigningKeys downloads the JSON placed in the namespace in S3 and unmarshals it into a core.SigningKeys
-func (s *S3Storage) SigningKeys(ctx context.Context, namespace string) (*core.SigningKeys, error) {
+func (s *S3Storage) signingKeys(ctx context.Context, pt providerType, hostname, namespace string) (*core.SigningKeys, error) {
 	if namespace == "" {
 		return nil, fmt.Errorf("namespace argument is empty")
 	}
+	key := signingKeysPath(s.bucketPrefix, pt, hostname, namespace)
+	exists, err := s.objectExists(ctx, key)
+	if err != nil {
+		return nil, err
+	} else if !exists {
+		return nil, core.ErrObjectNotFound
+	}
 
-	signingKeysRaw, err := s.download(ctx, signingKeysPath(s.bucketPrefix, namespace))
+	signingKeysRaw, err := s.download(ctx, key)
 	if err != nil {
 		return nil, fmt.Errorf("failed to download signing_keys.json for namespace %s: %w", namespace, err)
 	}
 
 	return unmarshalSigningKeys(signingKeysRaw)
+}
+
+// SigningKeys downloads the JSON placed in the namespace in S3 and unmarshals it into a core.SigningKeys
+func (s *S3Storage) SigningKeys(ctx context.Context, namespace string) (*core.SigningKeys, error) {
+	return s.signingKeys(ctx, internalProviderType, "", namespace)
+}
+
+func (s *S3Storage) MirroredSigningKeys(ctx context.Context, hostname, namespace string) (*core.SigningKeys, error) {
+	return s.signingKeys(ctx, mirrorProviderType, hostname, namespace)
+}
+
+func (s *S3Storage) uploadSigningKeys(ctx context.Context, pt providerType, hostname, namespace string, signingKeys *core.SigningKeys) error {
+	b, err := json.Marshal(signingKeys)
+	if err != nil {
+		return err
+	}
+	key := signingKeysPath(s.bucketPrefix, pt, hostname, namespace)
+	return s.upload(ctx, key, bytes.NewReader(b), true)
+}
+
+func (s *S3Storage) UploadMirroredSigningKeys(ctx context.Context, hostname, namespace string, signingKeys *core.SigningKeys) error {
+	return s.uploadSigningKeys(ctx, mirrorProviderType, hostname, namespace, signingKeys)
+}
+
+func (s *S3Storage) MirroredSha256Sum(ctx context.Context, provider *core.Provider) (*core.Sha256Sums, error) {
+	prefix := providerStoragePrefix(s.bucketPrefix, mirrorProviderType, provider.Hostname, provider.Namespace, provider.Name)
+	key := filepath.Join(prefix, provider.ShasumFileName())
+	shaSumBytes, err := s.download(ctx, key)
+	if err != nil {
+		return nil, errors.New("failed to download SHA256SUMS")
+	}
+
+	return core.NewSha256Sums(provider.ShasumFileName(), bytes.NewReader(shaSumBytes))
+}
+
+func (s *S3Storage) UploadMirroredFile(ctx context.Context, provider *core.Provider, fileName string, reader io.Reader) error {
+	prefix := providerStoragePrefix(s.bucketPrefix, mirrorProviderType, provider.Hostname, provider.Namespace, provider.Name)
+	key := filepath.Join(prefix, fileName)
+	return s.upload(ctx, key, reader, true)
 }
 
 func (s *S3Storage) presignedURL(ctx context.Context, key string) (string, error) {
@@ -407,16 +462,40 @@ func (s *S3Storage) objectExists(ctx context.Context, key string) (bool, error) 
 	return true, nil
 }
 
-func (s *S3Storage) download(ctx context.Context, path string) ([]byte, error) {
+func (s *S3Storage) upload(ctx context.Context, key string, reader io.Reader, overwrite bool) error {
+	// If we don't want to overwrite, check if the object exists
+	if !overwrite {
+		exists, err := s.objectExists(ctx, key)
+		if err != nil {
+			return err
+		} else if exists {
+			return ErrObjectAlreadyExists
+		}
+	}
+
+	input := &s3.PutObjectInput{
+		Bucket: aws.String(s.bucket),
+		Key:    aws.String(key),
+		Body:   reader,
+	}
+
+	if _, err := s.uploader.Upload(ctx, input); err != nil {
+		return fmt.Errorf("failed to upload: %w", err)
+	}
+
+	return nil
+}
+
+func (s *S3Storage) download(ctx context.Context, key string) ([]byte, error) {
 	buf := s3manager.NewWriteAtBuffer([]byte{})
 
 	input := &s3.GetObjectInput{
 		Bucket: aws.String(s.bucket),
-		Key:    aws.String(path),
+		Key:    aws.String(key),
 	}
 
 	if _, err := s.downloader.Download(ctx, buf, input); err != nil {
-		return nil, errors.Wrapf(err, "failed to download: %s", path)
+		return nil, errors.Wrapf(err, "failed to download: %s", key)
 	}
 
 	return buf.Bytes(), nil
@@ -469,7 +548,7 @@ func WithS3StorageSignedUrlExpiry(t time.Duration) S3StorageOption {
 }
 
 // NewS3Storage returns a fully initialized S3 storage.
-func NewS3Storage(ctx context.Context, bucket string, options ...S3StorageOption) (*S3Storage, error) {
+func NewS3Storage(ctx context.Context, bucket string, options ...S3StorageOption) (Storage, error) {
 	// Required- and default-values should be set here
 	s := &S3Storage{
 		bucket: bucket,

--- a/pkg/storage/s3_test.go
+++ b/pkg/storage/s3_test.go
@@ -217,8 +217,15 @@ func TestSigningKeys(t *testing.T) {
 	for _, tc := range testCases {
 		tc := tc
 		t.Run(tc.annotation, func(t *testing.T) {
-			s := S3Storage{}
-			s.downloader = &mockS3Downloader{payload: tc.payload, error: tc.returnError}
+			s := S3Storage{
+				downloader: &mockS3Downloader{payload: tc.payload, error: tc.returnError},
+				client: &mockS3Client{
+					errorFunc: func() error {
+						return nil
+					},
+				},
+			}
+
 			result, err := s.SigningKeys(context.Background(), tc.namespace)
 
 			if !tc.expectedError {

--- a/pkg/storage/storage.go
+++ b/pkg/storage/storage.go
@@ -3,7 +3,9 @@ package storage
 import (
 	"encoding/json"
 	"fmt"
+
 	"github.com/TierMobility/boring-registry/pkg/core"
+	"github.com/TierMobility/boring-registry/pkg/mirror"
 	"github.com/TierMobility/boring-registry/pkg/module"
 	"github.com/TierMobility/boring-registry/pkg/provider"
 )
@@ -15,6 +17,7 @@ const (
 type Storage interface {
 	provider.Storage
 	module.Storage
+	mirror.Storage
 }
 
 // unmarshalSigningKeys tries to unmarshal the byte-array into core.SigningKeys, and if that fails into core.GPGPublicKey.


### PR DESCRIPTION
This PR is the second (and better) iteration for a pull-through cache of providers queried via the provider mirror protocol. The first iteration is here: #22 .

It should also address issue #142 :)

The PR is currently in draft mode, as the implementation is not ready yet. I'll update this message with more information later.

Changes:
* Changed default S3 signed URL expiration limit from 30s to 5min