### PR TITLE
refactor: replace github.com/pkg/errors with stdlib errors package

### DIFF
--- a/cmd/archive.go
+++ b/cmd/archive.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -15,7 +16,6 @@ import (
 
 	"github.com/go-kit/kit/log/level"
 	"github.com/hashicorp/go-version"
-	"github.com/pkg/errors"
 )
 
 const (

--- a/cmd/server.go
+++ b/cmd/server.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/pprof"
@@ -11,16 +12,6 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/go-kit/kit/endpoint"
-	httptransport "github.com/go-kit/kit/transport/http"
-
-	"github.com/go-kit/kit/log"
-	"github.com/go-kit/kit/log/level"
-	"github.com/go-kit/kit/transport"
-	"github.com/pkg/errors"
-
-	"golang.org/x/sync/errgroup"
-
 	"github.com/TierMobility/boring-registry/pkg/auth"
 	"github.com/TierMobility/boring-registry/pkg/discovery"
 	"github.com/TierMobility/boring-registry/pkg/mirror"
@@ -28,8 +19,15 @@ import (
 	"github.com/TierMobility/boring-registry/pkg/provider"
 	"github.com/TierMobility/boring-registry/pkg/storage"
 
+	"github.com/go-kit/kit/endpoint"
+	"github.com/go-kit/kit/log"
+	"github.com/go-kit/kit/log/level"
+	"github.com/go-kit/kit/transport"
+	httptransport "github.com/go-kit/kit/transport/http"
+
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -83,7 +81,7 @@ var serverCmd = &cobra.Command{
 
 		mux, err := serveMux(ctx)
 		if err != nil {
-			return errors.Wrap(err, "failed to setup server")
+			return fmt.Errorf("failed to setup server: %w", err)
 		}
 
 		server := &http.Server{

--- a/cmd/upload.go
+++ b/cmd/upload.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -15,7 +16,6 @@ import (
 	"github.com/TierMobility/boring-registry/pkg/provider"
 
 	"github.com/hashicorp/go-version"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 

--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,6 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/hashicorp/hcl v1.0.0
 	github.com/okta/okta-jwt-verifier-golang/v2 v2.0.3
-	github.com/pkg/errors v0.9.1
 	github.com/prometheus/client_golang v1.17.0
 	github.com/spf13/cobra v1.8.0
 	github.com/spf13/pflag v1.0.5
@@ -78,6 +77,7 @@ require (
 	github.com/mitchellh/mapstructure v1.5.0 // indirect
 	github.com/patrickmn/go-cache v0.0.0-20180815053127-5633e0862627 // indirect
 	github.com/pelletier/go-toml/v2 v2.1.0 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/prometheus/client_model v0.5.0 // indirect
 	github.com/prometheus/common v0.45.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -74,6 +74,7 @@ github.com/envoyproxy/go-control-plane v0.9.1-0.20191026205805-5f8ba28d4473/go.m
 github.com/envoyproxy/go-control-plane v0.9.4/go.mod h1:6rpuAdCZL397s3pYoYcLgu1mIlRU8Am5FuJP05cCM98=
 github.com/envoyproxy/protoc-gen-validate v0.1.0/go.mod h1:iSmxcyjqTsJpI2R4NaDN7+kN2VEUnK/pcBlmesArF7c=
 github.com/frankban/quicktest v1.14.6 h1:7Xjx+VpznH+oBnejlPUj8oUpdxnVs4f8XU8WnHkI4W8=
+github.com/frankban/quicktest v1.14.6/go.mod h1:4ptaffx2x8+WTWXmUCuVU6aPUX1/Mz7zb5vbUoiM6w0=
 github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
 github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/go-kit/kit v0.13.0 h1:OoneCcHKHQ03LfBpoQCUfCluwd2Vt3ohz+kvbJneZAU=
@@ -117,7 +118,9 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.5/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/martian/v3 v3.3.2 h1:IqNFLAmvJOgVlpdEBiQbDc2EwKW77amAycfTuWKdfvw=
+github.com/google/martian/v3 v3.3.2/go.mod h1:oBOf6HBosgwRXnUGWUB05QECsc6uvmMiJ3+6W4l/CUk=
 github.com/google/s2a-go v0.1.7 h1:60BLSyTrOV4/haCDW4zb1guZItoSq8foHCXrAnjBo/o=
 github.com/google/s2a-go v0.1.7/go.mod h1:50CgR4k1jNlWBu4UfS4AcfhVe1r6pdZPygJ3R8F0Qdw=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
@@ -141,12 +144,15 @@ github.com/hashicorp/hcl v1.0.0/go.mod h1:E5yfLk+7swimpb2L/Alb/PJmXilQ/rhwaUYs4T
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/jarcoal/httpmock v1.1.0 h1:F47ChZj1Y2zFsCXxNkBPwNNKnAyOATcdQibk0qEdVCE=
+github.com/jarcoal/httpmock v1.1.0/go.mod h1:ATjnClrvW/3tijVmpL/va5Z3aAyGvqU3gCT8nX0Txik=
 github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
 github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGwWFoC7ycTf1rcQZHOlsJ6N8=
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
+github.com/kr/pretty v0.3.1/go.mod h1:hoEshYVHaxMs3cyo3Yncou5ZscifuDolrwPKZanG3xk=
 github.com/kr/text v0.2.0 h1:5Nx0Ya0ZqY2ygV366QzturHI13Jq95ApcVaJBhpS+AY=
+github.com/kr/text v0.2.0/go.mod h1:eLer722TekiGuMkidMxC/pM04lWEeraHUUmBw8l2grE=
 github.com/lestrrat-go/backoff/v2 v2.0.8 h1:oNb5E5isby2kiro9AgdHLv5N5tint1AnDVVf2E2un5A=
 github.com/lestrrat-go/backoff/v2 v2.0.8/go.mod h1:rHP/q/r9aT27n24JQLa7JhSQZCKBBOiM/uP402WwN8Y=
 github.com/lestrrat-go/blackmagic v1.0.2 h1:Cg2gVSc9h7sz9NOByczrbUvLopQmXrfFx//N+AkAr5k=
@@ -187,6 +193,7 @@ github.com/prometheus/common v0.45.0/go.mod h1:YJmSTw9BoKxJplESWWxlbyttQR4uaEcGy
 github.com/prometheus/procfs v0.12.0 h1:jluTpSng7V9hY0O2R9DzzJHYb2xULk9VTR1V1R/k6Bo=
 github.com/prometheus/procfs v0.12.0/go.mod h1:pcuDEFsWDnvcgNzo4EEweacyhjeA9Zk3cnaOZAZEfOo=
 github.com/rogpeppe/go-internal v1.10.0 h1:TMyTOH3F/DB16zRVcYyreMH6GnZZrwQVAoYjRBZyWFQ=
+github.com/rogpeppe/go-internal v1.10.0/go.mod h1:UQnix2H7Ngw/k4C5ijL5+65zddjncjaFoBhdsK/akog=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/sagikazarmark/locafero v0.4.0 h1:HApY1R9zGo4DBgr7dqsTH/JJxLTTsOt7u6keLGt6kNQ=
 github.com/sagikazarmark/locafero v0.4.0/go.mod h1:Pe1W6UlPYUk/+wc/6KFhbORCfqzgYEpgQ3O5fPuL3H4=
@@ -223,6 +230,7 @@ go.opentelemetry.io/otel v1.21.0/go.mod h1:QZzNPQPm1zLX4gZK4cMi+71eaorMSGT3A4znn
 go.opentelemetry.io/otel/metric v1.21.0 h1:tlYWfeo+Bocx5kLEloTjbcDwBuELRrIFxwdQ36PlJu4=
 go.opentelemetry.io/otel/metric v1.21.0/go.mod h1:o1p3CA8nNHW8j5yuQLdc1eeqEaPfzug24uvsyIEJRWM=
 go.opentelemetry.io/otel/sdk v1.19.0 h1:6USY6zH+L8uMH8L3t1enZPR3WFEmSTADlqldyHtJi3o=
+go.opentelemetry.io/otel/sdk v1.19.0/go.mod h1:NedEbbS4w3C6zElbLdPJKOpJQOrGUJ+GfzpjUvI0v1A=
 go.opentelemetry.io/otel/trace v1.21.0 h1:WD9i5gzvoUPuXIXH24ZNBudiarZDKuekPqi/E8fpfLc=
 go.opentelemetry.io/otel/trace v1.21.0/go.mod h1:LGbsEB0f9LGjN+OZaQQ26sohbOmiMR+BaslueVtS/qQ=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
@@ -350,10 +358,12 @@ google.golang.org/protobuf v1.31.0 h1:g0LDEJHgrBl9N9r17Ru3sqWhkIx2NB67okBHPwC7hs
 google.golang.org/protobuf v1.31.0/go.mod h1:HV8QOd/L58Z+nl8r43ehVNZIU/HEI6OcFqwMG9pJV4I=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c h1:Hei/4ADfdWqJk1ZMxUNpqntNwaWcugrBjAiHlqqRiVk=
+gopkg.in/check.v1 v1.0.0-20201130134442-10cb98267c6c/go.mod h1:JHkPIbrfpd72SG/EVd6muEfDQjcINNoR0C8j2r3qZ4Q=
 gopkg.in/ini.v1 v1.67.0 h1:Dgnx+6+nfE+IfzjUEISNeydPJh9AXNNsWbGP9KzCsOA=
 gopkg.in/ini.v1 v1.67.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.4.0 h1:D8xgwECY7CYvx+Y2n4sBz93Jn9JRvxdiyyo8CTfuKaY=
+gopkg.in/yaml.v2 v2.4.0/go.mod h1:RDklbk79AGWmwhnvt/jBztapEOGDOx6ZbXqjP6csGnQ=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/pkg/auth/provider_okta.go
+++ b/pkg/auth/provider_okta.go
@@ -2,10 +2,10 @@ package auth
 
 import (
 	"context"
+	"fmt"
 	"strings"
 
 	jwtverifier "github.com/okta/okta-jwt-verifier-golang/v2"
-	"github.com/pkg/errors"
 )
 
 type OktaProvider struct {
@@ -27,7 +27,7 @@ func (p *OktaProvider) Verify(ctx context.Context, token string) error {
 	}
 
 	if _, err := verifier.VerifyIdToken(token); err != nil {
-		return errors.Wrap(ErrInvalidToken, err.Error())
+		return fmt.Errorf("%v: %w", ErrInvalidToken, err)
 	}
 
 	return nil

--- a/pkg/mirror/transport.go
+++ b/pkg/mirror/transport.go
@@ -3,6 +3,7 @@ package mirror
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/url"
@@ -14,7 +15,6 @@ import (
 	"github.com/go-kit/kit/endpoint"
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 )
 
 type muxVar string

--- a/pkg/module/storage_inmem.go
+++ b/pkg/module/storage_inmem.go
@@ -2,6 +2,7 @@ package module
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"path"
@@ -10,7 +11,6 @@ import (
 	"github.com/TierMobility/boring-registry/pkg/core"
 
 	"github.com/go-kit/kit/log"
-	"github.com/pkg/errors"
 )
 
 // InmemStorage is a Storage implementation
@@ -33,9 +33,10 @@ func (s *InmemStorage) GetModule(_ context.Context, namespace, name, provider, v
 		Provider:  provider,
 		Version:   version,
 	}
-	module, ok := s.modules[m.ID(true)]
+	id := m.ID(true)
+	module, ok := s.modules[id]
 	if !ok {
-		return core.Module{}, errors.Wrap(errors.New("module not found"), "id")
+		return core.Module{}, fmt.Errorf("module not found: %s", id)
 	}
 
 	return module, nil
@@ -56,7 +57,7 @@ func (s *InmemStorage) ListModuleVersions(ctx context.Context, namespace, name, 
 	}
 
 	if len(modules) == 0 {
-		return nil, errors.Errorf("no modules found for namespace=%s name=%s provider=%s", namespace, name, provider)
+		return nil, fmt.Errorf("no modules found for namespace=%s name=%s provider=%s", namespace, name, provider)
 	}
 
 	return modules, nil
@@ -90,7 +91,7 @@ func (s *InmemStorage) UploadModule(ctx context.Context, namespace, name, provid
 
 	id := m.ID(true)
 	if _, ok := s.modules[id]; ok {
-		return core.Module{}, errors.Wrap(errors.New("exists already"), "id")
+		return core.Module{}, fmt.Errorf("module exists already: %s", id)
 	}
 
 	s.modules[id] = m

--- a/pkg/provider/transport.go
+++ b/pkg/provider/transport.go
@@ -2,13 +2,13 @@ package provider
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 
 	"github.com/go-kit/kit/auth/jwt"
 	"github.com/go-kit/kit/endpoint"
 	httptransport "github.com/go-kit/kit/transport/http"
 	"github.com/gorilla/mux"
-	"github.com/pkg/errors"
 )
 
 type muxVar string
@@ -57,12 +57,12 @@ func MakeHandler(svc Service, auth endpoint.Middleware, options ...httptransport
 func decodeListRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 	namespace, ok := ctx.Value(varNamespace).(string)
 	if !ok {
-		return nil, errors.Wrap(ErrVarMissing, "namespace")
+		return nil, fmt.Errorf("%w: namespace", ErrVarMissing)
 	}
 
 	name, ok := ctx.Value(varName).(string)
 	if !ok {
-		return nil, errors.Wrap(ErrVarMissing, "name")
+		return nil, fmt.Errorf("%w: name", ErrVarMissing)
 	}
 
 	return listRequest{
@@ -74,27 +74,27 @@ func decodeListRequest(ctx context.Context, r *http.Request) (interface{}, error
 func decodeDownloadRequest(ctx context.Context, r *http.Request) (interface{}, error) {
 	namespace, ok := ctx.Value(varNamespace).(string)
 	if !ok {
-		return nil, errors.Wrap(ErrVarMissing, "namespace")
+		return nil, fmt.Errorf("%w: namespace", ErrVarMissing)
 	}
 
 	name, ok := ctx.Value(varName).(string)
 	if !ok {
-		return nil, errors.Wrap(ErrVarMissing, "name")
+		return nil, fmt.Errorf("%w: name", ErrVarMissing)
 	}
 
 	version, ok := ctx.Value(varVersion).(string)
 	if !ok {
-		return nil, errors.Wrap(ErrVarMissing, "version")
+		return nil, fmt.Errorf("%w: version", ErrVarMissing)
 	}
 
 	os, ok := ctx.Value(varOS).(string)
 	if !ok {
-		return nil, errors.Wrap(ErrVarMissing, "os")
+		return nil, fmt.Errorf("%w: os", ErrVarMissing)
 	}
 
 	arch, ok := ctx.Value(varArch).(string)
 	if !ok {
-		return nil, errors.Wrap(ErrVarMissing, "arch")
+		return nil, fmt.Errorf("%w: arch", ErrVarMissing)
 	}
 
 	return downloadRequest{

--- a/pkg/storage/s3_test.go
+++ b/pkg/storage/s3_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
@@ -18,7 +19,6 @@ import (
 	s3manager "github.com/aws/aws-sdk-go-v2/feature/s3/manager"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
-	"github.com/pkg/errors"
 	assertion "github.com/stretchr/testify/assert"
 )
 


### PR DESCRIPTION
The package is unmaintained, we should probably try to get rid of it